### PR TITLE
Update NewCollection event to use data field for collection id

### DIFF
--- a/ownership-chain/precompile/laos-evolution/src/lib.rs
+++ b/ownership-chain/precompile/laos-evolution/src/lib.rs
@@ -65,11 +65,10 @@ where
 				match LaosEvolution::create_collection(owner.into()) {
 					Ok(collection_id) => {
 						LogsBuilder::new(context.address)
-							.log3(
+							.log2(
 								SELECTOR_LOG_NEW_COLLECTION,
-								H256::from_low_u64_be(collection_id.to_be()),
 								owner,
-								Vec::new(),
+								EvmDataWriter::new().write(collection_id).build(),
 							)
 							.record(handle)?;
 

--- a/ownership-chain/precompile/laos-evolution/src/tests.rs
+++ b/ownership-chain/precompile/laos-evolution/src/tests.rs
@@ -3,6 +3,8 @@
 //TODO: remove this and fix clippy issues
 #![allow(clippy::redundant_closure_call)]
 
+use core::str::FromStr;
+
 use super::*;
 use frame_support::assert_ok;
 use precompile_utils::{
@@ -78,7 +80,7 @@ fn create_collection_should_return_collection_id() {
 
 #[test]
 fn create_collection_should_generate_log() {
-	impl_precompile_mock_simple!(Mock, Ok(0), None, Ok(0.into()), None);
+	impl_precompile_mock_simple!(Mock, Ok(123), None, Ok(0.into()), None);
 
 	let input = EvmDataWriter::new_with_selector(Action::CreateCollection)
 		.write(Address(H160([1u8; 20])))
@@ -90,10 +92,20 @@ fn create_collection_should_generate_log() {
 	let logs = handle.logs;
 	assert_eq!(logs.len(), 1);
 	assert_eq!(logs[0].address, H160::zero());
-	assert_eq!(logs[0].topics.len(), 3);
+	assert_eq!(logs[0].topics.len(), 2);
 	assert_eq!(logs[0].topics[0], SELECTOR_LOG_NEW_COLLECTION.into());
-	assert_eq!(logs[0].topics[1], H256::from_low_u64_be(0));
-	assert_eq!(logs[0].data, Vec::<u8>::new());
+	assert_eq!(
+		logs[0].topics[1],
+		H256::from_str("0x0000000000000000000000000101010101010101010101010101010101010101")
+			.unwrap()
+	);
+	assert_eq!(
+		logs[0].data,
+		vec![
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 123
+		]
+	);
 }
 
 #[test]


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR fixes a bug in the NewCollection event where the collection id was not being correctly stored. The collection id is now stored in the data field of the event, instead of being passed as a separate argument. This change is reflected in both the main code and the corresponding tests.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`ownership-chain/precompile/laos-evolution/src/lib.rs`: Updated the NewCollection event to store the collection id in the data field. The collection id is now passed to the log2 function instead of log3, and is written using the EvmDataWriter.
`ownership-chain/precompile/laos-evolution/src/tests.rs`: Adjusted the tests to reflect the changes in the NewCollection event. The tests now check that the collection id is correctly stored in the data field of the event.
</details>
