### PR TITLE
Add Build Step to CI Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,10 @@ jobs:
     - uses: ./.github/actions/cache
       with:
         cache-key: build_and_push
+   
+    - name: Build
+        run: |
+          cargo build --release
 
     - name: Copy polkadot relay chain binary
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,8 +119,8 @@ jobs:
         cache-key: build_and_push
    
     - name: Build
-        run: |
-          cargo build --release -p laos-ownership
+      run: |
+        cargo build --release 
 
     - name: Copy polkadot relay chain binary
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
    
     - name: Build
         run: |
-          cargo build --release
+          cargo build --release -p laos-ownership
 
     - name: Copy polkadot relay chain binary
       run: |


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new step in the GitHub Actions CI workflow to compile the project's binary. This step uses the `cargo build --release` command to build the binary in release mode.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`.github/workflows/build.yml`: A new step named 'Build' has been added to the CI workflow. This step runs the command `cargo build --release` to compile the project's binary.
</details>
