### PR TITLE
Removal of Manual Nonce Management

### DIFF
--- a/ownership-chain/e2e-tests/tests/config.ts
+++ b/ownership-chain/e2e-tests/tests/config.ts
@@ -18,7 +18,6 @@ export const GENESIS_ACCOUNT_BALANCE = "77559934324363988853790420524572160";
 export const GAS_PRICE = "0x3B9ACA00";
 export const ETH_BLOCK_GAS_LIMIT = 15000000; // The same configuration as runtime
 export const GAS_LIMIT = ETH_BLOCK_GAS_LIMIT - 10000000; 
-export const GAS = "0x10000"; 
 
 // LAOS Evolution Contract
 export const LAOS_EVOLUTION_ABI = LaosEvolution.abi as AbiItem[];

--- a/ownership-chain/e2e-tests/tests/test-create-collection.ts
+++ b/ownership-chain/e2e-tests/tests/test-create-collection.ts
@@ -39,13 +39,10 @@ describeWithExistingNode("Frontier RPC (Create Collection)", (context) => {
     step("when collection is created event is emitted", async function () {
         this.timeout(70000);
 
-        let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
-
         const result = await contract.methods.createCollection(GENESIS_ACCOUNT).send({
             from: GENESIS_ACCOUNT,
             gas: GAS_LIMIT,
             gasPrice: GAS_PRICE,
-            nonce: nonce++,
         });
         expect(result.status).to.be.eq(true);
 

--- a/ownership-chain/e2e-tests/tests/test-evolution.ts
+++ b/ownership-chain/e2e-tests/tests/test-evolution.ts
@@ -64,9 +64,8 @@ describeWithExistingNode("Frontier RPC (Mint and Evolve Assets)", (context) => {
         const to = GENESIS_ACCOUNT;
         const tokenURI = "https://example.com";
 
-        let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
         const result = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI)
-            .send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
+            .send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
         expect(result.status).to.be.eq(true);
 
         expect(Object.keys(result.events).length).to.be.eq(1);
@@ -103,12 +102,10 @@ describeWithExistingNode("Frontier RPC (Mint and Evolve Assets)", (context) => {
         const tokenId = slotAndOwnerToTokenId(slot, to);
         const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
 
-        let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
-
-        const mintingResult = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
+        const mintingResult = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
         expect(mintingResult.status).to.be.eq(true);
 
-        const evolvingResult = await collectionContract.methods.evolveWithExternalURI(tokenIdDecimal, newTokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
+        const evolvingResult = await collectionContract.methods.evolveWithExternalURI(tokenIdDecimal, newTokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
         expect(evolvingResult.status).to.be.eq(true);
 
         const got = await collectionContract.methods.tokenURI(tokenIdDecimal).call();
@@ -125,12 +122,10 @@ describeWithExistingNode("Frontier RPC (Mint and Evolve Assets)", (context) => {
         const tokenId = slotAndOwnerToTokenId(slot, to);
         const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
 
-        let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
-
-        const mintingResult = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
+        const mintingResult = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
         expect(mintingResult.status).to.be.eq(true);
 
-        const evolvingResult = await collectionContract.methods.evolveWithExternalURI(tokenIdDecimal, newTokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
+        const evolvingResult = await collectionContract.methods.evolveWithExternalURI(tokenIdDecimal, newTokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
         expect(evolvingResult.status).to.be.eq(true);
 
         expect(Object.keys(evolvingResult.events).length).to.be.eq(1);


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes the manual management of nonce in the contract method calls. The changes are applied across multiple test files. The main points are:
- Removal of nonce calculation and incrementation before contract method calls.
- Simplification of contract method calls by removing the nonce parameter.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/e2e-tests/tests/config.ts`: The constant `GAS` was removed from the file.
- `ownership-chain/e2e-tests/tests/test-create-collection.ts`: Removed the calculation of nonce and its usage in the `createCollection` method call.
- `ownership-chain/e2e-tests/tests/test-evolution.ts`: Removed the calculation of nonce and its usage in the `mintWithExternalURI` and `evolveWithExternalURI` method calls.
</details>
