### PR TITLE
Refactor Collection Address Format

### DIFF
--- a/ownership-chain/e2e-tests/tests/test-create-collection.ts
+++ b/ownership-chain/e2e-tests/tests/test-create-collection.ts
@@ -56,7 +56,7 @@ describeWithExistingNode("Frontier RPC (Create Collection)", (context) => {
         expect(result.events.NewCollection.raw.topics[1]).to.be.eq(context.web3.utils.padLeft(GENESIS_ACCOUNT.toLowerCase(), 64));
 
         // event data
-        expect(result.events.NewCollection.raw.data).to.be.eq(context.web3.utils.padLeft(result.events.NewCollection.returnValues._collectionAddress, 64));
+        expect(result.events.NewCollection.raw.data.toLowerCase()).to.be.eq(context.web3.utils.padLeft(result.events.NewCollection.returnValues._collectionAddress, 64).toLowerCase());
     });
 
 });

--- a/ownership-chain/pallets/laos-evolution/src/lib.rs
+++ b/ownership-chain/pallets/laos-evolution/src/lib.rs
@@ -215,81 +215,67 @@ fn slot_and_owner_to_token_id(slot: Slot, owner: H160) -> Option<TokenId> {
 	Some(TokenId::from(bytes))
 }
 
+/// `ASSET_PRECOMPILE_ADDRESS_PREFIX` is a predefined prefix used to identify collection addresses.
+///
+/// All addresses that start with this prefix are considered as collection addresses.
+/// Since `CollectionId` is represented as a `u64`, it leaves these bits free to be
+/// utilized for such a prefix.
+///
+/// Usage of this prefix provides a consistent and recognizable pattern for distinguishing
+/// collection addresses from other types of addresses in the system.
+pub const ASSET_PRECOMPILE_ADDRESS_PREFIX: &[u8] =
+	&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe];
+
 /// Enum representing possible errors related to collections.
 #[derive(Debug, PartialEq)]
 pub enum CollectionError {
-	/// Error indicating that the provided address does not have the correct format.
-	InvalidFormat,
-	/// Error indicating that the provided address does not have a valid version.
-	InvalidVersion,
+	/// Error indicating that the provided address does not have the correct prefix.
+	InvalidPrefix,
 }
-
-/// Converts a `CollectionId` into a custom address type `Address`.
+/// Converts a `CollectionId` into an `Address`.
 ///
-/// The function constructs a 20-byte Ethereum-like address with a specific format:
-///  - The first 11 bytes are zeros.
-///  - The 12th byte is set to `1`, indicating the version.
-///  - The last 8 bytes represent the `CollectionId` in big-endian format.
-///
-/// This function is generic over the return type `Address`, which must be a type
-/// that can be constructed from a 20-byte array (`[u8; 20]`). This allows flexibility
-/// in the type of address returned, as long as it can be created from the byte array.
-///
-/// # Type Parameters
-///
-/// * `Address` - The type of the address to be returned. This type must implement `From<[u8; 20]>`.
+/// This function takes the given `CollectionId`, which is assumed to be a `u64`,
+/// and maps it into an `Address` address, prepending it with the `ASSET_PRECOMPILE_ADDRESS_PREFIX`.
 ///
 /// # Arguments
 ///
-/// * `collection_id` - The `CollectionId` (u64 value) to be converted into an address.
+/// * `collection_id`: The ID of the collection to be converted.
 ///
 /// # Returns
 ///
-/// An `Address` type representing the constructed address.
+/// * An `Address` representation of the collection ID.
 pub fn collection_id_to_address<Address: From<[u8; 20]>>(collection_id: CollectionId) -> Address {
-	let mut address = [0u8; 20];
-	address[11] = 1; // Set version byte to 1
-	address[12..].copy_from_slice(&collection_id.to_be_bytes());
-	address.into()
+	let mut bytes = [0u8; 20];
+	bytes[12..20].copy_from_slice(&collection_id.to_be_bytes());
+	for (i, byte) in ASSET_PRECOMPILE_ADDRESS_PREFIX.iter().enumerate() {
+		bytes[i] = *byte;
+	}
+	Address::from(bytes)
 }
 
-/// Converts a given address into a `CollectionId`.
+/// Converts an `Address` address into a `CollectionId` format.
 ///
-/// This function takes an `Address` and attempts to convert it into a `CollectionId`.
-/// The `Address` is expected to be a 20-byte array in a specific format:
-///  - The first 11 bytes should be zeros.
-///  - The 12th byte should be `1`, indicating the version.
-///  - The last 8 bytes represent the `CollectionId` in big-endian format.
+/// This function takes the given `Address` address, checks for the correct prefix, and extracts
+/// the `CollectionId` from it. If the prefix is incorrect, it returns a
+/// `CollectionError::InvalidPrefix` error.
 ///
-/// # Type Parameters
+/// # Arguments
 ///
-/// * `Address`: A type that can be converted into a 20-byte array.
-///
-/// # Parameters
-///
-/// * `address`: The address to convert into a `CollectionId`. It must implement `Into<[u8; 20]>`.
+/// * `address`: The `Address` address to be converted.
 ///
 /// # Returns
 ///
-/// This function returns a `Result<CollectionId, CollectionError>`:
-///  - `Ok(CollectionId)`: If the conversion is successful, returns the `CollectionId`.
-///  - `Err(CollectionError::InvalidFormat)`: If the first 11 bytes of the address are not zeros.
-///  - `Err(CollectionError::InvalidVersion)`: If the 12th byte of the address is not `1`.
+/// * A `Result` which is either the `CollectionId` or an error indicating the address is invalid.
 pub fn address_to_collection_id<Address>(address: Address) -> Result<CollectionId, CollectionError>
 where
 	Address: Into<[u8; 20]>,
 {
 	let address_bytes: [u8; 20] = address.into();
-
-	// Check if the first 11 bytes are zeros
-	for &byte in &address_bytes[..11] {
-		ensure!(byte == 0, CollectionError::InvalidFormat);
+	if &address_bytes[0..12] != ASSET_PRECOMPILE_ADDRESS_PREFIX {
+		return Err(CollectionError::InvalidPrefix)
 	}
+	let mut id_bytes = [0u8; 8];
+	id_bytes.copy_from_slice(&address_bytes[12..]);
 
-	// Check if the 12th byte is 1 (version byte)
-	ensure!(address_bytes[11] == 1, CollectionError::InvalidVersion);
-
-	let mut collection_id_bytes = [0u8; 8];
-	collection_id_bytes.copy_from_slice(&address_bytes[12..20]);
-	Ok(u64::from_be_bytes(collection_id_bytes))
+	Ok(CollectionId::from_be_bytes(id_bytes))
 }

--- a/ownership-chain/pallets/laos-evolution/src/tests.rs
+++ b/ownership-chain/pallets/laos-evolution/src/tests.rs
@@ -421,28 +421,19 @@ mod collection_id_conversion {
 	fn given_a_collection_id_from_id_to_address_works() {
 		let collection_id = 5;
 		let expected_address =
-			AccountId::from_str("0000000000000000000000010000000000000005").unwrap();
+			AccountId::from_str("fffffffffffffffffffffffe0000000000000005").unwrap();
 		assert_eq!(collection_id_to_address::<AccountId>(collection_id), expected_address);
 	}
 
 	#[test]
 	fn given_invalid_format_from_address_to_id_fails() {
 		let address = AccountId::from_str("0010000000000000000000010000000000000005").unwrap();
-		assert_err!(address_to_collection_id::<AccountId>(address), CollectionError::InvalidFormat);
-	}
-
-	#[test]
-	fn given_invalid_12th_byte_from_address_to_id_fails() {
-		let address = AccountId::from_str("0000000000000000000000020000000000000005").unwrap();
-		assert_err!(
-			address_to_collection_id::<AccountId>(address),
-			CollectionError::InvalidVersion
-		);
+		assert_err!(address_to_collection_id::<AccountId>(address), CollectionError::InvalidPrefix);
 	}
 
 	#[test]
 	fn given_valid_address_from_address_to_id_works() {
-		let address = AccountId::from_str("0000000000000000000000010000000000000005").unwrap();
+		let address = AccountId::from_str("fffffffffffffffffffffffe0000000000000005").unwrap();
 		let collection_id = address_to_collection_id::<AccountId>(address).unwrap();
 		assert_eq!(collection_id, 5);
 	}

--- a/ownership-chain/precompile/laos-evolution/src/tests.rs
+++ b/ownership-chain/precompile/laos-evolution/src/tests.rs
@@ -82,8 +82,8 @@ fn create_collection_should_return_collection_id() {
 	assert_ok!(
 		result,
 		succeed(H256::from_slice(&[
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
-			0, 0, 0
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+			255, 254, 0, 0, 0, 0, 0, 0, 0, 0
 		]))
 	);
 }
@@ -115,8 +115,8 @@ fn create_collection_should_generate_log() {
 	assert_eq!(
 		logs[0].data,
 		vec![
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
-			0, 0, 123
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+			255, 254, 0, 0, 0, 0, 0, 0, 0, 123
 		]
 	);
 }
@@ -131,7 +131,7 @@ fn mint_with_external_uri_should_generate_log() {
 		}
 	);
 
-	let collection_address = H160::from_str("0000000000000000000000010000000000000005").unwrap();
+	let collection_address = H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 	let input = EvmDataWriter::new_with_selector(Action::Mint)
 		.write(Address(H160::from_str(ALICE).unwrap())) // to
 		.write(U256::from(9)) // slot
@@ -224,7 +224,7 @@ fn call_unexistent_selector_should_fail() {
 fn call_owner_of_non_existent_collection() {
 	impl_precompile_mock_simple!(Mock, PrecompileMockParams::default());
 
-	let collection_address = H160::from_str("0000000000000000000000010000000000000005").unwrap();
+	let collection_address = H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 	let input = EvmDataWriter::new_with_selector(Action::Owner).build();
 	let mut handle = create_mock_handle(input, 0, 0, H160::zero());
 	handle.context.address = collection_address;
@@ -255,7 +255,7 @@ fn call_owner_of_collection_works() {
 
 	let owner = H160::from_low_u64_be(0x1234);
 	let input = EvmDataWriter::new_with_selector(Action::Owner).build();
-	let collection_address = H160::from_str("0000000000000000000000010000000000000005").unwrap();
+	let collection_address = H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 
 	let mut handle = create_mock_handle(input, 0, 0, H160::zero());
 	handle.context.address = collection_address;
@@ -267,7 +267,7 @@ fn call_owner_of_collection_works() {
 fn token_uri_returns_nothing_when_source_token_uri_is_none() {
 	impl_precompile_mock_simple!(Mock, PrecompileMockParams::default());
 
-	let collection_address = H160::from_str("0000000000000000000000010000000000000005").unwrap();
+	let collection_address = H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 	let input = EvmDataWriter::new_with_selector(Action::TokenURI)
 		.write(TokenId::from(0))
 		.build();
@@ -285,7 +285,7 @@ fn token_uri_returns_the_result_from_source() {
 		PrecompileMockParams { token_uri_result: Some(vec![1_u8, 10]), ..Default::default() }
 	);
 
-	let collection_address = H160::from_str("0000000000000000000000010000000000000005").unwrap();
+	let collection_address = H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 
 	let input = EvmDataWriter::new_with_selector(Action::TokenURI)
 		.write(TokenId::from(0))
@@ -309,7 +309,7 @@ fn mint_works() {
 	);
 
 	let to = H160::from_low_u64_be(1);
-	let collection_address = H160::from_str("0000000000000000000000010000000000000005").unwrap();
+	let collection_address = H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 
 	let input = EvmDataWriter::new_with_selector(Action::Mint)
 		.write(Address(to))
@@ -336,7 +336,7 @@ fn failing_mint_should_return_error() {
 	);
 
 	let to = H160::from_low_u64_be(1);
-	let collection_address = H160::from_str("0000000000000000000000010000000000000005").unwrap();
+	let collection_address = H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 
 	let input = EvmDataWriter::new_with_selector(Action::Mint)
 		.write(Address(to))
@@ -366,7 +366,7 @@ mod evolve {
 		);
 
 		let collection_address =
-			H160::from_str("0000000000000000000000010000000000000005").unwrap();
+			H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 		let input = EvmDataWriter::new_with_selector(Action::Evolve)
 			.write(U256::from(1))
 			.write(Bytes([1u8; 20].to_vec()))
@@ -384,7 +384,7 @@ mod evolve {
 		impl_precompile_mock_simple!(Mock, PrecompileMockParams::default());
 
 		let collection_address =
-			H160::from_str("0000000000000000000000010000000000000005").unwrap();
+			H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 		let token_id = 1;
 		let token_uri = Bytes([1u8; 20].to_vec());
 
@@ -428,7 +428,7 @@ mod evolve {
 		);
 
 		let collection_address =
-			H160::from_str("0000000000000000000000010000000000000005").unwrap();
+			H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap();
 		let input = EvmDataWriter::new_with_selector(Action::Evolve)
 			.write(U256::from(1))
 			.write(Bytes([1u8; 20].to_vec()))

--- a/ownership-chain/runtime/src/precompiles/test.rs
+++ b/ownership-chain/runtime/src/precompiles/test.rs
@@ -26,6 +26,6 @@ fn ethereum_precompiled_addresses_are_precompile() {
 	assert!(is_precompile(hash(5)).unwrap());
 	assert!(!is_precompile(hash(1026)).unwrap());
 	assert!(is_precompile(hash(1027)).unwrap());
-	assert!(is_precompile(H160::from_str("0x0000000000000000000000010000000000000005").unwrap())
+	assert!(is_precompile(H160::from_str("0xfffffffffffffffffffffffe0000000000000005").unwrap())
 		.unwrap());
 }


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR introduces a significant change in the way collection addresses are formatted in the system. The main changes include:
- A new predefined prefix `ASSET_PRECOMPILE_ADDRESS_PREFIX` is introduced for collection addresses.
- The function `collection_id_to_address` is updated to prepend the `ASSET_PRECOMPILE_ADDRESS_PREFIX` to the `CollectionId`.
- The function `address_to_collection_id` is updated to check for the correct prefix and extract the `CollectionId` from the address.
- The `CollectionError` enum is updated, replacing `InvalidFormat` and `InvalidVersion` with `InvalidPrefix`.
- Corresponding changes are made in the test files to reflect the new address format.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/pallets/laos-evolution/src/lib.rs`: Introduced a new predefined prefix for collection addresses. Updated the functions `collection_id_to_address` and `address_to_collection_id` to use this new prefix. Updated the `CollectionError` enum.
- `ownership-chain/pallets/laos-evolution/src/tests.rs`: Updated the tests to reflect the new collection address format.
- `ownership-chain/precompile/laos-evolution/src/tests.rs`: Updated the tests to reflect the new collection address format.
- `ownership-chain/runtime/src/precompiles/test.rs`: Updated the test to reflect the new collection address format.
</details>
