### PR TITLE
Update spec_version from 8 to 9 in RuntimeVersion

### DIFF
--- a/ownership-chain/e2e-tests/tests/config.ts
+++ b/ownership-chain/e2e-tests/tests/config.ts
@@ -5,7 +5,7 @@ import EvolutionCollectionFactory from "../build/contracts/EvolutionCollectionFa
 
 // Node config
 export const RUNTIME_SPEC_NAME = "frontier-template";
-export const RUNTIME_SPEC_VERSION = 8;
+export const RUNTIME_SPEC_VERSION = 9;
 export const RUNTIME_IMPL_VERSION = 0;
 export const RPC_PORT = 9999;
 

--- a/ownership-chain/runtime/src/lib.rs
+++ b/ownership-chain/runtime/src/lib.rs
@@ -211,7 +211,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frontier-template"),
 	impl_name: create_runtime_str!("frontier-template"),
 	authoring_version: 1,
-	spec_version: 8,
+	spec_version: 9,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR updates the `spec_version` in the `RuntimeVersion` struct from 8 to 9. This change is crucial for the runtime to recognize that a new version is available and to trigger the necessary updates.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/runtime/src/lib.rs`: Updated the `spec_version` from 8 to 9 in the `RuntimeVersion` struct.
</details>
