### PR TITLE
Adding Bootnodes to Klaos Network

### DIFF
--- a/ownership-chain/specs/klaos.json
+++ b/ownership-chain/specs/klaos.json
@@ -2,7 +2,11 @@
   "name": "klaos network",
   "id": "klaos_chain",
   "chainType": "Live",
-  "bootNodes": [],
+  "bootNodes": [
+    "/ip4/159.223.241.56/tcp/30334/p2p/12D3KooWK5UdnG9kkbAdGGS8Wg4tMVNKjqtDDhxKWyQTNgrJuVW3",
+    "/ip4/167.99.16.64/tcp/30334/p2p/12D3KooWJyy76xKUu36MyWALPp2AcqKzb7EqyUDeKWVfg3biEvjW",
+    "/ip4/64.225.82.80/tcp/30334/p2p/12D3KooWLMTiDN1yAWtDs2NShThPgBMvxfx2wdaXzRUcAgG4poW8"
+  ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0],
     ["/dns/telemetry-shard.gorengine.com/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]

--- a/ownership-chain/specs/klaos.raw.json
+++ b/ownership-chain/specs/klaos.raw.json
@@ -2,7 +2,11 @@
   "name": "klaos network",
   "id": "klaos_chain",
   "chainType": "Live",
-  "bootNodes": [],
+  "bootNodes": [
+    "/ip4/159.223.241.56/tcp/30334/p2p/12D3KooWK5UdnG9kkbAdGGS8Wg4tMVNKjqtDDhxKWyQTNgrJuVW3",
+    "/ip4/167.99.16.64/tcp/30334/p2p/12D3KooWJyy76xKUu36MyWALPp2AcqKzb7EqyUDeKWVfg3biEvjW",
+    "/ip4/64.225.82.80/tcp/30334/p2p/12D3KooWLMTiDN1yAWtDs2NShThPgBMvxfx2wdaXzRUcAgG4poW8"
+  ],
   "telemetryEndpoints": [
     [
       "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the addition of bootnodes to the Klaos network. The bootnodes are essential for new nodes to join the network as they provide the initial points of contact. Three bootnodes have been added in this PR.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/specs/klaos.json`: Added three bootnodes to the Klaos network configuration.
- `ownership-chain/specs/klaos.raw.json`: Replicated the addition of the three bootnodes in the raw configuration file for the Klaos network.
</details>
