### PR TITLE
Update Project Metadata and Naming in Node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace.package]
+description = "The LAOS parachain node."
 repository = "https://github.com/freeverseio/laos.git"
+homepage = "https://www.laosfoundation.io"
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 description = "The LAOS parachain node."
 repository = "https://github.com/freeverseio/laos.git"
 homepage = "https://www.laosfoundation.io"
+authors = ["Freeverse"]
 
 [workspace]
 resolver = "2"

--- a/ownership-chain/node/Cargo.toml
+++ b/ownership-chain/node/Cargo.toml
@@ -2,10 +2,9 @@
 name = "laos-ownership"
 version = "0.1.0"
 authors = ["Anonymous"]
-description = "A new Cumulus FRAME-based Substrate Node, ready for hacking together a parachain."
 license = "Unlicense"
-homepage = "https://substrate.io"
-repository = "https://github.com/paritytech/cumulus/"
+homepage = "https://github.com/freeverseio/laos"
+repository = "https://github.com/freeverseio/laos"
 edition = "2021"
 build = "build.rs"
 

--- a/ownership-chain/node/Cargo.toml
+++ b/ownership-chain/node/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "laos-ownership"
 version = "0.1.0"
-authors = ["Anonymous"]
-license = "Unlicense"
-homepage = "https://github.com/freeverseio/laos"
-repository = "https://github.com/freeverseio/laos"
 edition = "2021"
 build = "build.rs"
 

--- a/ownership-chain/node/Cargo.toml
+++ b/ownership-chain/node/Cargo.toml
@@ -2,6 +2,7 @@
 name = "laos-ownership"
 version = "0.1.0"
 edition = "2021"
+authors = { workspace = true }
 build = "build.rs"
 
 [dependencies]

--- a/ownership-chain/node/src/command.rs
+++ b/ownership-chain/node/src/command.rs
@@ -106,7 +106,7 @@ impl SubstrateCli for RelayChainCli {
 	}
 
 	fn support_url() -> String {
-		"https://github.com/paritytech/frontier-parachain-template/issues/new".into()
+		"https://github.com/freeverseio/laos/issues/new".into()
 	}
 
 	fn copyright_start_year() -> i32 {

--- a/ownership-chain/node/src/command.rs
+++ b/ownership-chain/node/src/command.rs
@@ -48,7 +48,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"Frontier Parachain Collator Template".into()
+		"LAOS Parachain Node".into()
 	}
 
 	fn impl_version() -> String {
@@ -57,7 +57,7 @@ impl SubstrateCli for Cli {
 
 	fn description() -> String {
 		format!(
-			"Frontier Parachain Collator Template\n\nThe command-line arguments provided first will be \
+			"LAOS Parachain Node\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",
@@ -70,11 +70,11 @@ impl SubstrateCli for Cli {
 	}
 
 	fn support_url() -> String {
-		"https://github.com/paritytech/frontier-parachain-template/issues/new".into()
+		"https://github.com/freeverseio/laos/issues/new".into()
 	}
 
 	fn copyright_start_year() -> i32 {
-		2020
+		2023
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
@@ -84,7 +84,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
 	fn impl_name() -> String {
-		"Frontier Parachain Collator Template".into()
+		"LAOS Parachain Node".into()
 	}
 
 	fn impl_version() -> String {
@@ -93,7 +93,7 @@ impl SubstrateCli for RelayChainCli {
 
 	fn description() -> String {
 		format!(
-			"Frontier Parachain Collator Template\n\nThe command-line arguments provided first will be \
+			"LAOS Parachain Node\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		{} <parachain-args> -- <relay-chain-args>",

--- a/ownership-chain/runtime/Cargo.toml
+++ b/ownership-chain/runtime/Cargo.toml
@@ -1,11 +1,6 @@
 [package]
 name = "laos-ownership-runtime"
 version = "0.1.0"
-authors = ["Anonymous"]
-description = "A new Cumulus FRAME-based Substrate Runtime, ready for hacking together a parachain."
-license = "Unlicense"
-homepage = "https://substrate.io"
-repository = "https://github.com/paritytech/cumulus/"
 edition = "2021"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR includes changes to update the project metadata and naming in the node. The main changes include:
- Renaming from "Frontier Parachain Collator Template" to "LAOS Parachain Node"
- Updating the support URL to point to the new project repository
- Changing the copyright start year from 2020 to 2023
- Updating the project metadata in the Cargo.toml file

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/node/src/command.rs`: Updated the implementation name, description, support URL, and copyright start year for both Cli and RelayChainCli.
- `ownership-chain/node/Cargo.toml`: Updated the project metadata including the homepage and repository URLs.
</details>
