### PR TITLE
Update Runtime Spec Version to 10

### DIFF
--- a/ownership-chain/e2e-tests/tests/config.ts
+++ b/ownership-chain/e2e-tests/tests/config.ts
@@ -5,7 +5,7 @@ import EvolutionCollectionFactory from "../build/contracts/EvolutionCollectionFa
 
 // Node config
 export const RUNTIME_SPEC_NAME = "frontier-template";
-export const RUNTIME_SPEC_VERSION = 9;
+export const RUNTIME_SPEC_VERSION = 10;
 export const RUNTIME_IMPL_VERSION = 0;
 export const RPC_PORT = 9999;
 

--- a/ownership-chain/runtime/src/lib.rs
+++ b/ownership-chain/runtime/src/lib.rs
@@ -210,7 +210,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frontier-template"),
 	impl_name: create_runtime_str!("frontier-template"),
 	authoring_version: 1,
-	spec_version: 9,
+	spec_version: 10,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR updates the runtime specification version from 9 to 10. The changes include:
- Updating the spec version in the runtime configuration file
- Updating the spec version in the end-to-end test configuration file

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/runtime/src/lib.rs`: Updated the 'spec_version' from 9 to 10 in the runtime configuration.
- `ownership-chain/e2e-tests/tests/config.ts`: Updated the 'RUNTIME_SPEC_VERSION' from 9 to 10 in the end-to-end test configuration.
</details>
