### PR TITLE
Addition of KLAOS Disclaimer in the Command File

### DIFF
--- a/ownership-chain/node/src/command.rs
+++ b/ownership-chain/node/src/command.rs
@@ -334,7 +334,7 @@ pub fn run() -> Result<()> {
 				info!("-----------------------------------------------------------");
 				info!(" The KLAOS Parachain on Kusama is a test chain for");
 				info!(" the LAOS Parachain on Polkadot.");
-				info!(" KLAOS is not endorsed by the LAOS Foundation nor Freeverse");
+				info!(" KLAOS is not endorsed by either the LAOS Foundation or Freeverse");
 				info!(" for real-value transactions involving the KLAOS token");
 				info!(" https://disclaimer.klaos.laosfoundation.io");
 				info!("-----------------------------------------------------------");

--- a/ownership-chain/node/src/command.rs
+++ b/ownership-chain/node/src/command.rs
@@ -330,6 +330,16 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(&cli.run.normalize())?;
 			let collator_options = cli.run.collator_options();
 
+			if runner.config().chain_spec.id().starts_with("klaos") {
+				info!("-----------------------------------------------------------");
+				info!(" The KLAOS Parachain on Kusama is a test chain for");
+				info!(" the LAOS Parachain on Polkadot.");
+				info!(" KLAOS is not endorsed by the LAOS Foundation nor Freeverse");
+				info!(" for real-value transactions involving the KLAOS token");
+				info!(" https://disclaimer.klaos.laosfoundation.io");
+				info!("-----------------------------------------------------------");
+			};
+
 			runner.run_node_until_exit(|config| async move {
 				let hwbench = (!cli.no_hardware_benchmarks)
 					.then_some(config.database.path().map(|database_path| {

--- a/ownership-chain/node/src/command.rs
+++ b/ownership-chain/node/src/command.rs
@@ -331,13 +331,13 @@ pub fn run() -> Result<()> {
 			let collator_options = cli.run.collator_options();
 
 			if runner.config().chain_spec.id().starts_with("klaos") {
-				info!("-----------------------------------------------------------");
+				info!("-----------------------------------------------------------------");
 				info!(" The KLAOS Parachain on Kusama is a test chain for");
 				info!(" the LAOS Parachain on Polkadot.");
 				info!(" KLAOS is not endorsed by either the LAOS Foundation or Freeverse");
 				info!(" for real-value transactions involving the KLAOS token");
 				info!(" https://disclaimer.klaos.laosfoundation.io");
-				info!("-----------------------------------------------------------");
+				info!("-----------------------------------------------------------------");
 			};
 
 			runner.run_node_until_exit(|config| async move {


### PR DESCRIPTION
## type:
Enhancement

___
## description:
This PR introduces a disclaimer message for the KLAOS Parachain on Kusama. The disclaimer is displayed when the chain_spec id starts with "klaos". The disclaimer message informs users that KLAOS is a test chain for the LAOS Parachain on Polkadot and is not endorsed by the LAOS Foundation nor Freeverse for real-value transactions involving the KLAOS token. A link to the full disclaimer is also provided.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/node/src/command.rs`: Added a conditional statement to check if the chain_spec id starts with "klaos". If it does, a disclaimer message is displayed.
</details>
