### PR TITLE
Update Runtime Spec Version to 601

### DIFF
--- a/ownership-chain/e2e-tests/tests/config.ts
+++ b/ownership-chain/e2e-tests/tests/config.ts
@@ -5,7 +5,7 @@ import EvolutionCollectionFactory from "../build/contracts/EvolutionCollectionFa
 
 // Node config
 export const RUNTIME_SPEC_NAME = "frontier-template";
-export const RUNTIME_SPEC_VERSION = 10;
+export const RUNTIME_SPEC_VERSION = 601;
 export const RUNTIME_IMPL_VERSION = 0;
 export const RPC_PORT = 9999;
 

--- a/ownership-chain/runtime/src/lib.rs
+++ b/ownership-chain/runtime/src/lib.rs
@@ -210,7 +210,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frontier-template"),
 	impl_name: create_runtime_str!("frontier-template"),
 	authoring_version: 1,
-	spec_version: 10,
+	spec_version: 601,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR updates the runtime spec version from 10 to 601 in two files:
- In the Rust file `ownership-chain/runtime/src/lib.rs`, the `spec_version` in the `RuntimeVersion` constant is updated.
- In the TypeScript file `ownership-chain/e2e-tests/tests/config.ts`, the `RUNTIME_SPEC_VERSION` constant is updated.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/runtime/src/lib.rs`: The `spec_version` in the `RuntimeVersion` constant is updated from 10 to 601.
- `ownership-chain/e2e-tests/tests/config.ts`: The `RUNTIME_SPEC_VERSION` constant is updated from 10 to 601.
</details>
