### PR TITLE
Addition of a new bootnode to the klaos.raw.json file

### DIFF
--- a/ownership-chain/specs/klaos.raw.json
+++ b/ownership-chain/specs/klaos.raw.json
@@ -5,7 +5,8 @@
   "bootNodes": [
     "/ip4/159.223.242.241/tcp/30334/p2p/12D3KooWPLfdfdDuNA2EcQQg1UfniDw2cJHjhcS98Vgj3pyvepgd",
     "/ip4/159.223.241.56/tcp/30334/p2p/12D3KooWP4hW5sQsS61yLWqgSnEEAUePdveMvqMdZxVWz4a4M6n7",
-    "/ip4/64.225.82.80/tcp/30334/p2p/12D3KooWCEZ635J1LtCSX95vSjk6WzAm6oHdzKdEhiKzLNtiUvpT"
+    "/ip4/64.225.82.80/tcp/30334/p2p/12D3KooWCEZ635J1LtCSX95vSjk6WzAm6oHdzKdEhiKzLNtiUvpT",
+    "/dns4/klaos-boot-0.gorengine.com/tcp/30334/p2p/12D3KooWCEZ635J1LtCSX95vSjk6WzAm6oHdzKdEhiKzLNtiUvpT"
   ],
   "telemetryEndpoints": [
     [

--- a/ownership-chain/specs/klaos.raw.json
+++ b/ownership-chain/specs/klaos.raw.json
@@ -6,7 +6,7 @@
     "/ip4/159.223.242.241/tcp/30334/p2p/12D3KooWPLfdfdDuNA2EcQQg1UfniDw2cJHjhcS98Vgj3pyvepgd",
     "/ip4/159.223.241.56/tcp/30334/p2p/12D3KooWP4hW5sQsS61yLWqgSnEEAUePdveMvqMdZxVWz4a4M6n7",
     "/ip4/64.225.82.80/tcp/30334/p2p/12D3KooWCEZ635J1LtCSX95vSjk6WzAm6oHdzKdEhiKzLNtiUvpT",
-    "/dns4/klaos-boot-0.gorengine.com/tcp/30334/p2p/12D3KooWCEZ635J1LtCSX95vSjk6WzAm6oHdzKdEhiKzLNtiUvpT"
+    "/dns4/klaos-boot-0.gorengine.com/tcp/30334/p2p/12D3KooWAkbe8ecKSGUyRjgZwh8DifGiu5oe6s1VbVdBcVmc7mkS"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR introduces the following changes:
- A new bootnode has been added to the klaos.raw.json file.
- This bootnode is located at "klaos-boot-0.gorengine.com" and operates on TCP port 30334.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `ownership-chain/specs/klaos.raw.json`: A new bootnode has been added to the list of bootNodes. The new bootnode is "/dns4/klaos-boot-0.gorengine.com/tcp/30334/p2p/12D3KooWAkbe8ecKSGUyRjgZwh8DifGiu5oe6s1VbVdBcVmc7mkS".
</details>
