### PR TITLE
Addition of try-runtime for klaos in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,10 +103,10 @@ jobs:
           cargo build --release --package laos-ownership --features=try-runtime
       - name: Try Runtime for Caladan
         run: |
-          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://161.35.247.178:9944
+          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://161.35.247.178:9944
       - name: Try Runtime for Klaos
         run: |
-          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://143.198.248.225:9944
+          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://143.198.248.225:9944
   
   e2e-tests:
     runs-on: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,9 +101,11 @@ jobs:
       - name: Build
         run: |
           cargo build --release --package laos-ownership --features=try-runtime
-      - name: Try Runtime
+      - name: Try Runtime for Caladan
         run: |
           RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://161.35.247.178:9944
+      - name: Try Runtime for Klaos
+        run: |
           RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://143.198.248.225:9944
   
   e2e-tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,8 +103,8 @@ jobs:
           cargo build --release --package laos-ownership --features=try-runtime
       - name: Try Runtime
         run: |
-          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://161.35.247.178:9944
-          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri wss://rpc.klaos.laosfoundation.io
+          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://161.35.247.178:9944
+          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://143.198.248.225:9944
   
   e2e-tests:
     runs-on: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Try Runtime
         run: |
           RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://161.35.247.178:9944
+          RUST_LOG=try-runtime ./target/release/laos-ownership try-runtime --runtime ./target/release/wbuild/laos-ownership-runtime/laos_ownership_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri wss://rpc.klaos.laosfoundation.io
   
   e2e-tests:
     runs-on: 


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR introduces an enhancement to the GitHub Actions workflow file (build.yml). It adds a new try-runtime command for the klaos environment in the build job. This command is expected to perform runtime checks on the klaos environment.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/build.yml`: A new try-runtime command has been added to the build job. This command is set to run on the klaos environment using the klaos specific RPC endpoint (wss://rpc.klaos.laosfoundation.io).
</details>
