### PR TITLE
Addition of CI on Release Branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 # Controls when the action will run.
 on:
   push:
-    branches: [main]
+    branches: [main, release/v*]
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR enhances the CI/CD pipeline by adding the 'release/v*' branches to the list of branches that trigger the GitHub Actions workflow. Previously, the workflow was only triggered by pushes to the 'main' branch. Now, it will also be triggered by pushes to any 'release/v*' branch.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/build.yml`: The 'on.push.branches' section of the GitHub Actions workflow file has been updated to include 'release/v*' branches. This means that the workflow will now be triggered by pushes to any 'release/v*' branch, in addition to the 'main' branch.
</details>
