### PR TITLE
Minimize Conditional Test Code in Ownership-Chain Runtime

### DIFF
--- a/ownership-chain/runtime/src/lib.rs
+++ b/ownership-chain/runtime/src/lib.rs
@@ -8,8 +8,6 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 #[cfg(test)]
 mod tests;
-#[cfg(test)]
-pub use tests::ParachainXcmRouter;
 
 mod weights;
 pub mod xcm_config;

--- a/ownership-chain/runtime/src/xcm_config.rs
+++ b/ownership-chain/runtime/src/xcm_config.rs
@@ -154,7 +154,7 @@ pub type XcmRouter = staging_xcm_builder::WithUniqueTopic<(
 
 /// Use different router in `xcm-simulator` tests.
 #[cfg(test)]
-pub type XcmRouter = crate::ParachainXcmRouter<ParachainInfo>;
+pub type XcmRouter = crate::tests::ParachainXcmRouter<ParachainInfo>;
 
 #[cfg(feature = "runtime-benchmarks")]
 parameter_types! {


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR focuses on minimizing the conditional test code in the `ownership-chain/runtime` module:
- The `ParachainXcmRouter` is no longer publicly used in the main `lib.rs` file. It's now directly referenced in the `xcm_config.rs` file.
- The `XcmRouter` type for tests in `xcm_config.rs` has been updated to directly use `crate::tests::ParachainXcmRouter<ParachainInfo>`.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/runtime/src/lib.rs<br><br>

**The conditional test code has been minimized. The <br>`ParachainXcmRouter` is no longer publicly used in the main <br>`lib.rs` file. Instead, it's now directly referenced in the <br>`xcm_config.rs` file.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/257/files#diff-b0f69a71ca20f9dbda0917139a7a931cd6503375c8833428c8ac431ea693aef4"> +0/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>xcm_config.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/runtime/src/xcm_config.rs<br><br>

**The `XcmRouter` type for tests has been updated to directly <br>use `crate::tests::ParachainXcmRouter<ParachainInfo>`, <br>instead of `crate::ParachainXcmRouter<ParachainInfo>`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/257/files#diff-1dbe2457025b5709cf649511760734a81ac4a1e630184989c73bddc9be5589a7"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>