### PR TITLE
Update to version 0.9.0 and add versioning tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5377,7 +5377,7 @@ dependencies = [
 
 [[package]]
 name = "laos-ownership-runtime"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -7520,7 +7520,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-evolution-collection"
-version = "2.0.0-dev"
+version = "0.9.0"
 dependencies = [
  "evm",
  "fp-evm",
@@ -7547,7 +7547,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-evolution-collection-factory"
-version = "2.0.0-dev"
+version = "0.9.0"
 dependencies = [
  "evm",
  "fp-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "laos-ownership"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "cumulus-client-cli",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "laos-precompile-utils"
-version = "0.4.3"
+version = "0.9.0"
 dependencies = [
  "evm",
  "fp-evm",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "laos-precompile-utils-macro"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "num_enum",
  "proc-macro2",
@@ -7061,7 +7061,7 @@ dependencies = [
 
 [[package]]
 name = "ownership-parachain-primitives"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "fp-account",
  "frame-support",
@@ -7705,7 +7705,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-laos-evolution"
-version = "4.0.0-dev"
+version = "0.9.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ description = "The LAOS parachain node."
 repository = "https://github.com/freeverseio/laos.git"
 homepage = "https://www.laosfoundation.io"
 authors = ["Freeverse"]
+version = "0.9.0"
 
 [workspace]
 resolver = "2"

--- a/ownership-chain/e2e-tests/tests/config.ts
+++ b/ownership-chain/e2e-tests/tests/config.ts
@@ -5,7 +5,7 @@ import EvolutionCollectionFactory from "../build/contracts/EvolutionCollectionFa
 
 // Node config
 export const RUNTIME_SPEC_NAME = "frontier-template";
-export const RUNTIME_SPEC_VERSION = 800;
+export const RUNTIME_SPEC_VERSION = 900;
 export const RUNTIME_IMPL_VERSION = 0;
 export const RPC_PORT = 9999;
 

--- a/ownership-chain/node/Cargo.toml
+++ b/ownership-chain/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laos-ownership"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 authors = { workspace = true }
 build = "build.rs"

--- a/ownership-chain/pallets/laos-evolution/Cargo.toml
+++ b/ownership-chain/pallets/laos-evolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-laos-evolution"
-version = "4.0.0-dev"
+version = { workspace = true }
 homepage = "https://freeverse.io"
 edition = "2021"
 license = "MIT-0"

--- a/ownership-chain/precompile/evolution-collection-factory/Cargo.toml
+++ b/ownership-chain/precompile/evolution-collection-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-evolution-collection-factory"
-version = "2.0.0-dev"
+version = { workspace = true }
 description = "Evolution collection factory precompile"
 repository = "https://github.com/freeverseio/laos"
 edition = "2021"

--- a/ownership-chain/precompile/evolution-collection/Cargo.toml
+++ b/ownership-chain/precompile/evolution-collection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-evolution-collection"
-version = "2.0.0-dev"
+version = { workspace = true }
 description = "Collection evolver and minter precompile"
 repository = "https://github.com/freeverseio/laos"
 edition = "2021"

--- a/ownership-chain/precompile/utils/Cargo.toml
+++ b/ownership-chain/precompile/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "laos-precompile-utils"
 authors = ["StakeTechnologies", "PureStake"]
 description = "Utils to write EVM precompiles."
-version = "0.4.3"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/ownership-chain/precompile/utils/macro/Cargo.toml
+++ b/ownership-chain/precompile/utils/macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "laos-precompile-utils-macro"
 authors = ["StakeTechnologies", "PureStake"]
 description = ""
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [lib]

--- a/ownership-chain/primitives/Cargo.toml
+++ b/ownership-chain/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ownership-parachain-primitives"
 description = "Primitives of Ownership parachain runtime."
-version = "0.1.0"
+version = { workspace = true }
 authors = ["Freeverse"]
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/ownership-chain/runtime/Cargo.toml
+++ b/ownership-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laos-ownership-runtime"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/ownership-chain/runtime/src/lib.rs
+++ b/ownership-chain/runtime/src/lib.rs
@@ -210,7 +210,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frontier-template"),
 	impl_name: create_runtime_str!("frontier-template"),
 	authoring_version: 1,
-	spec_version: 800,
+	spec_version: 900,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/ownership-chain/runtime/src/tests/mod.rs
+++ b/ownership-chain/runtime/src/tests/mod.rs
@@ -3,6 +3,7 @@
 #![cfg(test)]
 mod constant_tests;
 mod precompile_tests;
+mod spec_version;
 mod xcm_mock;
 mod xcm_tests;
 

--- a/ownership-chain/runtime/src/tests/spec_version.rs
+++ b/ownership-chain/runtime/src/tests/spec_version.rs
@@ -1,0 +1,77 @@
+use crate::VERSION;
+use std::{
+	io::{Error, ErrorKind},
+	num::ParseIntError,
+};
+
+fn version_to_int(version: &str) -> Result<u32, Error> {
+	let parts: Vec<&str> = version.split('.').collect();
+	if parts.len() != 3 {
+		return Err(Error::new(ErrorKind::InvalidInput, "Invalid version format"));
+	}
+
+	let major = parts[0]
+		.parse::<u32>()
+		.map_err(|e: ParseIntError| Error::new(ErrorKind::InvalidInput, e))?;
+	let minor = parts[1]
+		.parse::<u32>()
+		.map_err(|e: ParseIntError| Error::new(ErrorKind::InvalidInput, e))?;
+	let patch = parts[2]
+		.parse::<u32>()
+		.map_err(|e: ParseIntError| Error::new(ErrorKind::InvalidInput, e))?;
+
+	Ok(major * 10000 + minor * 100 + patch)
+}
+
+#[test]
+fn test_standard_version() {
+	assert_eq!(version_to_int("1.2.3").unwrap(), 10203);
+}
+
+#[test]
+fn test_version_with_leading_zeros() {
+	assert_eq!(version_to_int("0.9.0").unwrap(), 900);
+}
+
+#[test]
+fn test_version_with_more_than_three_parts() {
+	match version_to_int("1.2.3.4") {
+		Err(e) => assert_eq!(e.kind(), ErrorKind::InvalidInput),
+		_ => panic!("Expected an InvalidInput error"),
+	}
+}
+
+#[test]
+fn test_version_with_non_numeric_characters() {
+	match version_to_int("a.b.c") {
+		Err(e) => assert_eq!(e.kind(), ErrorKind::InvalidInput),
+		_ => panic!("Expected an InvalidInput error"),
+	}
+}
+
+#[test]
+fn test_empty_version() {
+	match version_to_int("") {
+		Err(e) => assert_eq!(e.kind(), ErrorKind::InvalidInput),
+		_ => panic!("Expected an InvalidInput error"),
+	}
+}
+
+#[test]
+fn test_0_0_1_should_be_1() {
+	assert_eq!(version_to_int("0.0.1").unwrap(), 1);
+}
+
+#[test]
+fn test_runtime_version_should_be_derived_from_package_version() {
+	let package_version = env!("CARGO_PKG_VERSION");
+	let derived_runtime_version = version_to_int(package_version);
+
+	assert!(derived_runtime_version.is_ok(), "Version conversion failed");
+
+	assert_eq!(
+		derived_runtime_version.unwrap(),
+		VERSION.spec_version,
+		"Derived runtime version does not match expected spec_version"
+	);
+}

--- a/ownership-chain/runtime/src/tests/spec_version.rs
+++ b/ownership-chain/runtime/src/tests/spec_version.rs
@@ -20,7 +20,20 @@ fn version_to_int(version: &str) -> Result<u32, Error> {
 		.parse::<u32>()
 		.map_err(|e: ParseIntError| Error::new(ErrorKind::InvalidInput, e))?;
 
+	// check all the numbers are less than 100
+	if major >= 100 || minor >= 100 || patch >= 100 {
+		return Err(Error::new(ErrorKind::InvalidInput, "Invalid version format"));
+	}
+
 	Ok(major * 10000 + minor * 100 + patch)
+}
+
+#[test]
+fn test_version_member_is_100_should_error() {
+	match version_to_int("100.0.0") {
+		Err(e) => assert_eq!(e.kind(), ErrorKind::InvalidInput),
+		_ => panic!("Expected an InvalidInput error"),
+	}
 }
 
 #[test]

--- a/ownership-chain/runtime/src/tests/spec_version.rs
+++ b/ownership-chain/runtime/src/tests/spec_version.rs
@@ -4,6 +4,24 @@ use std::{
 	num::ParseIntError,
 };
 
+/// Converts a version string in the format "major.minor.patch" to an integer.
+/// Each part of the version (major, minor, patch) must be a number less than 100.
+/// The resulting integer is in the format major*10000 + minor*100 + patch.
+///
+/// # Arguments
+/// * `version` - A string slice representing the version.
+///
+/// # Returns
+/// A `Result` containing either the integer representation of the version
+/// or an `Error` if the input format is incorrect or any part of the version
+/// is 100 or greater.
+///
+/// # Examples
+/// ```
+/// let version = "1.2.3";
+/// let int_version = version_to_int(version).unwrap();
+/// assert_eq!(int_version, 10203);
+/// ```
 fn version_to_int(version: &str) -> Result<u32, Error> {
 	let parts: Vec<&str> = version.split('.').collect();
 	if parts.len() != 3 {
@@ -20,9 +38,9 @@ fn version_to_int(version: &str) -> Result<u32, Error> {
 		.parse::<u32>()
 		.map_err(|e: ParseIntError| Error::new(ErrorKind::InvalidInput, e))?;
 
-	// check all the numbers are less than 100
+	// Check all the numbers are less than 100
 	if major >= 100 || minor >= 100 || patch >= 100 {
-		return Err(Error::new(ErrorKind::InvalidInput, "Invalid version format"));
+		return Err(Error::new(ErrorKind::InvalidInput, "Version number must be less than 100"));
 	}
 
 	Ok(major * 10000 + minor * 100 + patch)


### PR DESCRIPTION
## Type
enhancement, tests


___

## Description
This PR includes several enhancements and tests:
- The `spec_version` has been updated from 800 to 900 in the runtime configuration.
- A new test module `spec_version` has been added to test the versioning system.
- The `RUNTIME_SPEC_VERSION` has been updated from 800 to 900 in the e2e tests configuration.
- The version has been updated to 0.9.0 in the main `Cargo.toml` file, and the `workspace` field has been added.
- The version of several packages has been set to use the workspace version.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/runtime/src/lib.rs<br><br>

**The `spec_version` has been updated from 800 to 900.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-b0f69a71ca20f9dbda0917139a7a931cd6503375c8833428c8ac431ea693aef4"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/e2e-tests/tests/config.ts<br><br>

**The `RUNTIME_SPEC_VERSION` has been updated from 800 to 900.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-02c263a6e8b3847f277a70f0ea700a1184eb1aa7742e62b25a5329d67edc8a63"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        Cargo.toml<br><br>

**The version has been updated to 0.9.0. The `workspace` field <br>has been added.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542"> +1/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/node/Cargo.toml<br><br>

**The version has been set to use the workspace version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-a95acab9d237247f78755bd16f676aebbc0591ffb4200abbadb951bd28d18be6"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/laos-evolution/Cargo.toml<br><br>

**The version has been set to use the workspace version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-b21e921ed8ed2ed2bbf6673dfe24a7093b1a4aa973d3515570a874ee3ea6764c"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/evolution-collection-factory/Cargo.toml<br><br>

**The version has been set to use the workspace version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-85349d448f7665a8e7282a2387dbc75b27d7a4e14f9727978dbd0378aa243307"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/evolution-collection/Cargo.toml<br><br>

**The version has been set to use the workspace version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-30ea770bf8ca64aad723ea8ab492a57e18eae9a9390570f35b9746d6e5138ad8"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/utils/Cargo.toml<br><br>

**The version has been set to use the workspace version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-025f8df1213c0e9b863fbbc675434f7eea792cec150a78cdb604fa333a2f1f03"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/utils/macro/Cargo.toml<br><br>

**The version has been set to use the workspace version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-dc7bd105ac23656ca662c30e038de65a7383bb5102e08753c422919c9e14b175"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/primitives/Cargo.toml<br><br>

**The version has been set to use the workspace version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-1254592a14dcc0a9783c990549ceaa96c04ee38332f4e8e8f1c869f8521592c9"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/runtime/Cargo.toml<br><br>

**The version has been set to use the workspace version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-a6f1e3deb5d45fdcea9465ba45b4c048309ff47223bd15d61c1fe1340e98200f"> +1/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/runtime/src/tests/mod.rs<br><br>

**A new test module `spec_version` has been added.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-ac443d4befbe7cc699f85f0db740bd8448d68c43ba09e9b7e30f6e68a0740eeb"> +1/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>spec_version.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/runtime/src/tests/spec_version.rs<br><br>

**A new file has been added that contains tests for the <br>versioning system. It includes tests for version format, <br>conversion, and consistency with the package version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/258/files#diff-c270cfbdf701526a7448804c3f4e4f6a7f28162238e3b7573eff7d54f3fe8aea"> +90/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>