### PR TITLE
Update Runtime Version to 900

### DIFF
--- a/ownership-chain/e2e-tests/tests/config.ts
+++ b/ownership-chain/e2e-tests/tests/config.ts
@@ -5,7 +5,7 @@ import EvolutionCollectionFactory from "../build/contracts/EvolutionCollectionFa
 
 // Node config
 export const RUNTIME_SPEC_NAME = "frontier-template";
-export const RUNTIME_SPEC_VERSION = 800;
+export const RUNTIME_SPEC_VERSION = 900;
 export const RUNTIME_IMPL_VERSION = 0;
 export const RPC_PORT = 9999;
 

--- a/ownership-chain/runtime/src/lib.rs
+++ b/ownership-chain/runtime/src/lib.rs
@@ -210,7 +210,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frontier-template"),
 	impl_name: create_runtime_str!("frontier-template"),
 	authoring_version: 1,
-	spec_version: 800,
+	spec_version: 900,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## Type
enhancement


___

## Description
This PR includes updates to the runtime version in two files:
- In `ownership-chain/runtime/src/lib.rs`, the `spec_version` in the `VERSION` constant has been updated from 800 to 900.
- In `ownership-chain/e2e-tests/tests/config.ts`, the `RUNTIME_SPEC_VERSION` constant has been updated from 800 to 900.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/runtime/src/lib.rs<br><br>

**The `spec_version` in the `VERSION` constant of the runtime <br>has been updated from 800 to 900.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/259/files#diff-b0f69a71ca20f9dbda0917139a7a931cd6503375c8833428c8ac431ea693aef4"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/e2e-tests/tests/config.ts<br><br>

**The `RUNTIME_SPEC_VERSION` constant in the configuration has <br>been updated from 800 to 900.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/259/files#diff-02c263a6e8b3847f277a70f0ea700a1184eb1aa7742e62b25a5329d67edc8a63"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>