### PR TITLE
Add new pallet for asset metadata extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7093,6 +7093,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-asset-metadata-extender"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.1.0#c8d2251cafadc108ba2f1f8a3208dc547ff38901"

--- a/ownership-chain/pallets/asset-metadata-extender/Cargo.toml
+++ b/ownership-chain/pallets/asset-metadata-extender/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "pallet-asset-metadata-extender"
+version = "0.1.0"
+homepage = "https://freeverse.io"
+edition = "2021"
+license = "MIT-0"
+publish = false
+
+[dependencies]
+parity-scale-codec = { workspace = true, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-core = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"frame-support/std",
+	"frame-system/std",
+    	"sp-core/std",
+	"sp-runtime/std",
+]
+
+[dev-dependencies]
+sp-io = { workspace = true }

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -77,11 +77,11 @@ pub mod pallet {
 		},
 	}
 
-	// Customs errors for this pallet
+	/// Customs errors for this pallet
 	#[pallet::error]
 	#[derive(PartialEq)]
 	pub enum Error<T> {
-		// One claimer one can perform one extension for a given universal location
+		/// A claimer can perform one metadata extension for a given universal location
 		MetadataExtensionAlreadyExists,
 	}
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -46,7 +46,7 @@ pub mod pallet {
 		UniversalLocationOf<T>,
 		Blake2_128Concat,
 		Index,
-		MetadataExtension<T>,
+		MetadataExtensionDetails<T>,
 		OptionQuery,
 	>;
 
@@ -102,7 +102,7 @@ impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLo
 		IndexedMetadataExtensions::<T>::insert(
 			universal_location.clone(),
 			index,
-			MetadataExtension { claimer: claimer.clone(), token_uri: token_uri.clone() },
+			MetadataExtensionDetails { claimer: claimer.clone(), token_uri: token_uri.clone() },
 		);
 		ClaimerTokenURI::<T>::insert(
 			claimer.clone(),

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -74,6 +74,14 @@ pub mod pallet {
 			claimer: AccountIdOf<T>,
 			token_uri: TokenUriOf<T>,
 		},
+
+		/// Extension updated
+		/// parameters. [universal_location, claimer, token_uri]
+		ExtensionUpdated {
+			universal_location: UniversalLocationOf<T>,
+			claimer: AccountIdOf<T>,
+			token_uri: TokenUriOf<T>,
+		},
 	}
 
 	/// Customs errors for this pallet
@@ -82,11 +90,13 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// A claimer can perform one extension for a given universal location
 		ExtensionAlreadyExists,
+		/// A claimer can update an extension only if it exists
+		ExtensionDoesNotExist,
 	}
 }
 
 impl<T: Config> AssetMetadataExtender<T> for Pallet<T> {
-	fn create_metadata_extension(
+	fn create_token_uri_extension(
 		claimer: AccountIdOf<T>,
 		universal_location: UniversalLocationOf<T>,
 		token_uri: TokenUriOf<T>,
@@ -110,6 +120,30 @@ impl<T: Config> AssetMetadataExtender<T> for Pallet<T> {
 		ExtensionsCounter::<T>::insert(universal_location.clone(), next_index);
 
 		Self::deposit_event(Event::ExtensionCreated { universal_location, claimer, token_uri });
+
+		Ok(())
+	}
+
+	fn update_token_uri_extension(
+		claimer: AccountIdOf<T>,
+		universal_location: UniversalLocationOf<T>,
+		token_uri: TokenUriOf<T>,
+	) -> DispatchResult {
+		ensure!(
+			TokenUrisByClaimerAndLocation::<T>::contains_key(
+				claimer.clone(),
+				universal_location.clone()
+			),
+			Error::<T>::ExtensionDoesNotExist
+		);
+
+		TokenUrisByClaimerAndLocation::<T>::insert(
+			claimer.clone(),
+			universal_location.clone(),
+			token_uri.clone(),
+		);
+
+		Self::deposit_event(Event::ExtensionUpdated { claimer, universal_location, token_uri });
 
 		Ok(())
 	}

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -85,9 +85,7 @@ pub mod pallet {
 	}
 }
 
-impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLocationOf<T>>
-	for Pallet<T>
-{
+impl<T: Config> AssetMetadataExtender<T> for Pallet<T> {
 	fn create_metadata_extension(
 		claimer: AccountIdOf<T>,
 		universal_location: UniversalLocationOf<T>,

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -5,7 +5,7 @@ pub mod types;
 
 use frame_support::pallet_prelude::*;
 pub use pallet::*;
-use sp_runtime::{traits::One, ArithmeticError, DispatchError};
+use sp_runtime::{traits::One, ArithmeticError, DispatchResult};
 use traits::AssetMetadataExtender;
 use types::*;
 
@@ -92,7 +92,7 @@ impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLo
 		claimer: AccountIdOf<T>,
 		universal_location: UniversalLocationOf<T>,
 		token_uri: TokenUriOf<T>,
-	) -> Result<(), DispatchError> {
+	) -> DispatchResult {
 		ensure!(
 			!ClaimerTokenURI::<T>::contains_key(claimer.clone(), universal_location.clone()),
 			Error::<T>::MetadataExtensionAlreadyExists

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -39,8 +39,8 @@ pub mod pallet {
 
 	/// Records all metadata extensions with index for a given asset location
 	#[pallet::storage]
-	#[pallet::getter(fn indexed_metadata_extensions_details)]
-	pub(super) type IndexedMetadataExtensionsDetails<T: Config> = StorageDoubleMap<
+	#[pallet::getter(fn indexed_metadata_extensions)]
+	pub(super) type IndexedMetadataExtensions<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		UniversalLocationOf<T>,
@@ -52,8 +52,8 @@ pub mod pallet {
 
 	/// Records all token URIs associated with a given claimer who performed the metadata extension.
 	#[pallet::storage]
-	#[pallet::getter(fn claimer_token_uri)]
-	pub(super) type ClaimerTokenURI<T: Config> = StorageDoubleMap<
+	#[pallet::getter(fn metadata_extensions)]
+	pub(super) type MetadataExtensions<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		AccountIdOf<T>,
@@ -92,17 +92,17 @@ impl<T: Config> AssetMetadataExtender<T> for Pallet<T> {
 		token_uri: TokenUriOf<T>,
 	) -> DispatchResult {
 		ensure!(
-			!ClaimerTokenURI::<T>::contains_key(claimer.clone(), universal_location.clone()),
+			!MetadataExtensions::<T>::contains_key(claimer.clone(), universal_location.clone()),
 			Error::<T>::MetadataExtensionAlreadyExists
 		);
 
 		let index = Self::metadata_extensions_counter(universal_location.clone());
-		IndexedMetadataExtensionsDetails::<T>::insert(
+		IndexedMetadataExtensions::<T>::insert(
 			universal_location.clone(),
 			index,
 			MetadataExtensionDetails { claimer: claimer.clone(), token_uri: token_uri.clone() },
 		);
-		ClaimerTokenURI::<T>::insert(
+		MetadataExtensions::<T>::insert(
 			claimer.clone(),
 			universal_location.clone(),
 			token_uri.clone(),

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -82,7 +82,7 @@ pub mod pallet {
 	#[derive(PartialEq)]
 	pub enum Error<T> {
 		// One claimer one can perform one extension for a given universal location
-		ExtensionAlreadyExists,
+		MetadataExtensionAlreadyExists,
 	}
 }
 
@@ -99,7 +99,7 @@ impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLo
 				claimer.clone(),
 				universal_location.clone()
 			) == false,
-			Error::<T>::ExtensionAlreadyExists
+			Error::<T>::MetadataExtensionAlreadyExists
 		);
 
 		let index = Self::metadata_extensions_counter(universal_location.clone());

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -1,0 +1,68 @@
+#![cfg_attr(not(feature = "std"), no_std)] // duda para que esto
+use frame_support::pallet_prelude::*;
+pub use pallet::*;
+use sp_runtime::{traits::One, ArithmeticError, DispatchError};
+use traits::AssetMetadataExtender; // duda para que esto
+pub mod traits;
+
+/// Wrapper around `BoundedVec` for `tokenUri`
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_); // duda para que esto
+
+	/// Configure the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		// /// Because this pallet emits events, it depends on the runtime's definition of an event.
+		// type RuntimeEvent: From<Event<Self>> + IsType<<Self as
+		// frame_system::Config>::RuntimeEvent>; // duda entender
+	}
+
+	/// Universal location extensions counter
+	#[pallet::storage]
+	#[pallet::getter(fn universal_location_extensions_counter)]
+	pub(super) type UniversalLocationExtensionsCounter<T: Config> =
+		StorageMap<_, Blake2_128Concat, u32, u32, OptionQuery>;
+	// TODO u32
+
+	/// TODO
+	#[pallet::storage]
+	#[pallet::getter(fn universal_location_extensions)]
+	pub(super) type UniversalLocationExtensions<T: Config> =
+		StorageDoubleMap<_, Blake2_128Concat, u32, Blake2_128Concat, u32, u32, OptionQuery>; // TODO u32 and
+
+	/// TODO
+	#[pallet::storage]
+	#[pallet::getter(fn claimer_extensions)]
+	pub(super) type ClaimerExtensions<T: Config> =
+		StorageDoubleMap<_, Blake2_128Concat, u32, Blake2_128Concat, u32, u32, OptionQuery>; // TODO u32
+}
+
+impl<T: Config> AssetMetadataExtender for Pallet<T> {
+	fn create_extension(
+		claimer: u32,
+		universal_location: u32,
+		token_uri: u32,
+	) -> Result<(), DispatchError> {
+		// TODO ensure ul + claimer doesnt exist
+
+		// insert extension
+		let index = Self::universal_location_extensions_counter(universal_location).unwrap();
+		UniversalLocationExtensions::<T>::insert(universal_location, index, token_uri);
+		// insert claimer extension
+		ClaimerExtensions::<T>::insert(claimer, universal_location, token_uri);
+		// increase index
+		let next_index = index.checked_add(One::one()).ok_or(ArithmeticError::Overflow)?;
+		UniversalLocationExtensionsCounter::<T>::insert(universal_location, next_index);
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -51,7 +51,7 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
-	/// Records all token URIs associated with a given claimer who performed the extension.
+	/// Records all token URIs associated with a given claimer who performed the metadata extension.
 	#[pallet::storage]
 	#[pallet::getter(fn claimer_metadata_extensions)]
 	pub(super) type ClaimerMetadataExtensions<T: Config> = StorageDoubleMap<

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -34,7 +34,7 @@ pub mod pallet {
 	/// Asset metadata extensions counter for a given location
 	#[pallet::storage]
 	#[pallet::getter(fn metadata_extensions_counter)]
-	pub(super) type IndexedMetadataExtensionsCounter<T: Config> =
+	pub(super) type MetadataExtensionsCounter<T: Config> =
 		StorageMap<_, Blake2_128Concat, UniversalLocationOf<T>, Index, ValueQuery>;
 
 	/// Records all metadata extensions with index for a given asset location
@@ -110,7 +110,7 @@ impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLo
 			token_uri.clone(),
 		);
 		let next_index = index.checked_add(One::one()).ok_or(ArithmeticError::Overflow)?;
-		IndexedMetadataExtensionsCounter::<T>::insert(universal_location.clone(), next_index);
+		MetadataExtensionsCounter::<T>::insert(universal_location.clone(), next_index);
 
 		Self::deposit_event(Event::MetadataExtensionCreated {
 			universal_location,

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -39,8 +39,8 @@ pub mod pallet {
 
 	/// Records all metadata extensions with index for a given asset location
 	#[pallet::storage]
-	#[pallet::getter(fn indexed_metadata_extensions)]
-	pub(super) type IndexedMetadataExtensions<T: Config> = StorageDoubleMap<
+	#[pallet::getter(fn indexed_metadata_extensions_details)]
+	pub(super) type IndexedMetadataExtensionsDetails<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		UniversalLocationOf<T>,
@@ -99,7 +99,7 @@ impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLo
 		);
 
 		let index = Self::metadata_extensions_counter(universal_location.clone());
-		IndexedMetadataExtensions::<T>::insert(
+		IndexedMetadataExtensionsDetails::<T>::insert(
 			universal_location.clone(),
 			index,
 			MetadataExtensionDetails { claimer: claimer.clone(), token_uri: token_uri.clone() },

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -34,7 +34,7 @@ pub mod pallet {
 
 	/// Asset metadata extensions counter for a given location
 	#[pallet::storage]
-	#[pallet::getter(fn asset_metadata_extensions_counter)]
+	#[pallet::getter(fn metadata_extensions_counter)]
 	pub(super) type MetadataExtensionsCounter<T: Config> =
 		StorageMap<_, Blake2_128Concat, UniversalLocationOf<T>, Index, ValueQuery>;
 
@@ -102,7 +102,7 @@ impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLo
 			Error::<T>::ExtensionAlreadyExists
 		);
 
-		let index = Self::asset_metadata_extensions_counter(universal_location.clone());
+		let index = Self::metadata_extensions_counter(universal_location.clone());
 		MetadataExtensions::<T>::insert(
 			universal_location.clone(),
 			index,

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -52,8 +52,8 @@ pub mod pallet {
 
 	/// Records all token URIs associated with a given claimer who performed the metadata extension.
 	#[pallet::storage]
-	#[pallet::getter(fn claimer_metadata_extensions)]
-	pub(super) type ClaimerIndexedMetadataExtensions<T: Config> = StorageDoubleMap<
+	#[pallet::getter(fn claimer_token_uri)]
+	pub(super) type ClaimerTokenURI<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		AccountIdOf<T>,
@@ -94,10 +94,7 @@ impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLo
 		token_uri: TokenUriOf<T>,
 	) -> Result<(), DispatchError> {
 		ensure!(
-			!ClaimerIndexedMetadataExtensions::<T>::contains_key(
-				claimer.clone(),
-				universal_location.clone()
-			),
+			!ClaimerTokenURI::<T>::contains_key(claimer.clone(), universal_location.clone()),
 			Error::<T>::MetadataExtensionAlreadyExists
 		);
 
@@ -107,7 +104,7 @@ impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLo
 			index,
 			MetadataExtension { claimer: claimer.clone(), token_uri: token_uri.clone() },
 		);
-		ClaimerIndexedMetadataExtensions::<T>::insert(
+		ClaimerTokenURI::<T>::insert(
 			claimer.clone(),
 			universal_location.clone(),
 			token_uri.clone(),

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -1,9 +1,13 @@
 #![cfg_attr(not(feature = "std"), no_std)] // duda para que esto
+
+pub mod traits;
+pub mod types;
+
 use frame_support::pallet_prelude::*;
 pub use pallet::*;
 use sp_runtime::{traits::One, ArithmeticError, DispatchError};
-use traits::AssetMetadataExtender; // duda para que esto
-pub mod traits;
+use traits::AssetMetadataExtender;
+use types::*;
 
 /// Wrapper around `BoundedVec` for `tokenUri`
 #[frame_support::pallet]
@@ -16,47 +20,102 @@ pub mod pallet {
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		// /// Because this pallet emits events, it depends on the runtime's definition of an event.
-		// type RuntimeEvent: From<Event<Self>> + IsType<<Self as
-		// frame_system::Config>::RuntimeEvent>; // duda entender
+		/// Because this pallet emits events, it depends on the runtime's definition of an event.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// Limit for the length of `token_uri`
+		#[pallet::constant]
+		type MaxTokenUriLength: Get<u32>;
+
+		/// Limit for the length of `universal_location`
+		#[pallet::constant]
+		type MaxUniversalLocationLength: Get<u32>;
 	}
 
-	/// Universal location extensions counter
+	/// Universal location extensions counter TODO docs
 	#[pallet::storage]
 	#[pallet::getter(fn universal_location_extensions_counter)]
 	pub(super) type UniversalLocationExtensionsCounter<T: Config> =
-		StorageMap<_, Blake2_128Concat, u32, u32, OptionQuery>;
-	// TODO u32
+		StorageMap<_, Blake2_128Concat, UniversalLocationOf<T>, Index, ValueQuery>;
 
-	/// TODO
+	// TODO docs
 	#[pallet::storage]
 	#[pallet::getter(fn universal_location_extensions)]
-	pub(super) type UniversalLocationExtensions<T: Config> =
-		StorageDoubleMap<_, Blake2_128Concat, u32, Blake2_128Concat, u32, u32, OptionQuery>; // TODO u32 and
+	pub(super) type UniversalLocationExtensions<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		UniversalLocationOf<T>,
+		Blake2_128Concat,
+		Index,
+		Extension<T>,
+		OptionQuery,
+	>;
 
-	/// TODO
+	// TODO docs
 	#[pallet::storage]
 	#[pallet::getter(fn claimer_extensions)]
-	pub(super) type ClaimerExtensions<T: Config> =
-		StorageDoubleMap<_, Blake2_128Concat, u32, Blake2_128Concat, u32, u32, OptionQuery>; // TODO u32
+	pub(super) type ClaimerExtensions<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		AccountIdOf<T>,
+		Blake2_128Concat,
+		UniversalLocationOf<T>,
+		TokenUriOf<T>,
+		OptionQuery,
+	>;
+
+	/// Events for this pallet.
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Metadata extension created
+		/// parameters. [universal_location, claimer, token_uri]
+		ExtensionCreated {
+			universal_location: UniversalLocationOf<T>, /* TODO change universal_location ->
+			                                             * location */
+			claimer: AccountIdOf<T>,
+			token_uri: TokenUriOf<T>,
+		},
+	}
+
+	// Customs errors for this pallet
+	#[pallet::error]
+	#[derive(PartialEq)]
+	pub enum Error<T> {
+		// One claimer one can perform one extension for a given universal location
+		ExtensionAlreadyExists,
+	}
 }
 
-impl<T: Config> AssetMetadataExtender for Pallet<T> {
+impl<T: Config> AssetMetadataExtender<AccountIdOf<T>, TokenUriOf<T>, UniversalLocationOf<T>>
+	for Pallet<T>
+{
 	fn create_extension(
-		claimer: u32,
-		universal_location: u32,
-		token_uri: u32,
+		claimer: AccountIdOf<T>,
+		universal_location: UniversalLocationOf<T>,
+		token_uri: TokenUriOf<T>,
 	) -> Result<(), DispatchError> {
-		// TODO ensure ul + claimer doesnt exist
+		ensure!(
+			ClaimerExtensions::<T>::contains_key(claimer.clone(), universal_location.clone()) ==
+				false,
+			Error::<T>::ExtensionAlreadyExists
+		);
 
-		// insert extension
-		let index = Self::universal_location_extensions_counter(universal_location).unwrap();
-		UniversalLocationExtensions::<T>::insert(universal_location, index, token_uri);
-		// insert claimer extension
-		ClaimerExtensions::<T>::insert(claimer, universal_location, token_uri);
-		// increase index
+		let index = Self::universal_location_extensions_counter(universal_location.clone());
+		UniversalLocationExtensions::<T>::insert(
+			universal_location.clone(),
+			index,
+			Extension { claimer: claimer.clone(), token_uri: token_uri.clone() },
+		);
+		ClaimerExtensions::<T>::insert(
+			claimer.clone(),
+			universal_location.clone(),
+			token_uri.clone(),
+		);
 		let next_index = index.checked_add(One::one()).ok_or(ArithmeticError::Overflow)?;
-		UniversalLocationExtensionsCounter::<T>::insert(universal_location, next_index);
+		UniversalLocationExtensionsCounter::<T>::insert(universal_location.clone(), next_index);
+
+		Self::deposit_event(Event::ExtensionCreated { universal_location, claimer, token_uri });
 
 		Ok(())
 	}

--- a/ownership-chain/pallets/asset-metadata-extender/src/mock.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/mock.rs
@@ -1,12 +1,13 @@
 use crate as pallet_asset_metadata_extender;
 use frame_support::{
+	parameter_types,
 	traits::{ConstU16, ConstU64},
 	weights::constants::RocksDbWeight,
 };
 use sp_core::{H160, H256};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage,
+	BoundedVec, BuildStorage,
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -21,6 +22,10 @@ frame_support::construct_runtime!(
 );
 
 pub type AccountId = H160;
+pub type TokenUri =
+	BoundedVec<u8, <Test as pallet_asset_metadata_extender::Config>::MaxTokenUriLength>;
+pub type UniversalLocation =
+	BoundedVec<u8, <Test as pallet_asset_metadata_extender::Config>::MaxUniversalLocationLength>;
 
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;
@@ -48,8 +53,15 @@ impl frame_system::Config for Test {
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
+parameter_types! {
+	pub const MaxTokenUriLength: u32 = 512;
+	pub const MaxUniversalLocationLength: u32 = 512;
+}
+
 impl pallet_asset_metadata_extender::Config for Test {
-	// type RuntimeEvent = RuntimeEvent;
+	type RuntimeEvent = RuntimeEvent;
+	type MaxUniversalLocationLength = MaxUniversalLocationLength;
+	type MaxTokenUriLength = MaxTokenUriLength;
 }
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/ownership-chain/pallets/asset-metadata-extender/src/mock.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/mock.rs
@@ -7,7 +7,7 @@ use frame_support::{
 use sp_core::{H160, H256};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
-	BoundedVec, BuildStorage,
+	BuildStorage,
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -21,11 +21,7 @@ frame_support::construct_runtime!(
 	}
 );
 
-pub type AccountId = H160;
-pub type TokenUri =
-	BoundedVec<u8, <Test as pallet_asset_metadata_extender::Config>::MaxTokenUriLength>;
-pub type UniversalLocation =
-	BoundedVec<u8, <Test as pallet_asset_metadata_extender::Config>::MaxUniversalLocationLength>;
+type AccountId = H160;
 
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;

--- a/ownership-chain/pallets/asset-metadata-extender/src/mock.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/mock.rs
@@ -1,0 +1,57 @@
+use crate as pallet_asset_metadata_extender;
+use frame_support::{
+	traits::{ConstU16, ConstU64},
+	weights::constants::RocksDbWeight,
+};
+use sp_core::{H160, H256};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Test
+	{
+		System: frame_system,
+		AssetMetadataExtender: pallet_asset_metadata_extender,
+	}
+);
+
+pub type AccountId = H160;
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = RocksDbWeight;
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Nonce = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+impl pallet_asset_metadata_extender::Config for Test {
+	// type RuntimeEvent = RuntimeEvent;
+}
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
+}

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -1,88 +1,119 @@
-use crate::{mock::*, traits::AssetMetadataExtender as _};
-use frame_support::assert_ok;
+use crate::{mock::*, traits::AssetMetadataExtender as _, Error, Event};
+use frame_support::{assert_noop, assert_ok};
+use sp_core::{bounded_vec, H160};
+use sp_runtime::BoundedVec;
 
 // UL stands for Universal Location
+
+fn create_extension(
+	claimer: AccountId,
+	universal_location: UniversalLocation,
+	token_uri: TokenUri,
+) {
+	assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+}
 
 #[test]
 fn given_an_ul_and_token_uri_i_can_create_asset_extension() {
 	new_test_ext().execute_with(|| {
-		let universal_location = 0;
-		let token_uri = 1;
-		let claimer = 2;
-		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		// Go past genesis block so events get deposited
+		System::set_block_number(1);
+		let claimer = H160::zero();
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
 
-		// TODO event is emmitted
+		create_extension(claimer, universal_location.clone(), token_uri.clone());
+
+		System::assert_last_event(
+			Event::ExtensionCreated { universal_location, claimer, token_uri }.into(),
+		);
 	});
 }
 
-// #[test]
-// fn given_an_ul_and_token_uri_i_can_update_an_existing_extension() {
-// 	new_test_ext().execute_with(|| {});
-// }
+#[test]
+fn given_an_ul_and_token_uri_i_cannot_create_twice_asset_extension_with_same_claimer() {
+	new_test_ext().execute_with(|| {
+		let claimer = H160::zero();
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+
+		create_extension(claimer, universal_location.clone(), token_uri.clone());
+		assert_noop!(
+			AssetMetadataExtender::create_extension(claimer, universal_location, token_uri),
+			Error::<Test>::ExtensionAlreadyExists
+		);
+	});
+}
 
 #[test]
-fn given_a_universal_location_after_creating_extension_counter_increases() {
-	// TODO test same claimer several times and same asset with several claimers
+fn given_an_universal_location_after_creating_extension_counter_increases() {
 	new_test_ext().execute_with(|| {
-		let universal_location = 0;
-		let another_universal_location = 1;
-		let token_uri = 1;
-		let claimer = 2;
+		let claimer = H160::zero();
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+
+		// create first extension for the given UL
 		assert_eq!(
-			AssetMetadataExtender::universal_location_extensions_counter(universal_location)
-				.unwrap(),
+			AssetMetadataExtender::universal_location_extensions_counter(
+				universal_location.clone()
+			),
 			0
 		);
-		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+
+		create_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
-			AssetMetadataExtender::universal_location_extensions_counter(universal_location)
-				.unwrap(),
+			AssetMetadataExtender::universal_location_extensions_counter(
+				universal_location.clone()
+			),
 			1
 		);
+
+		// check that no other UL has been affected
+		let another_universal_location: BoundedVec<u8, MaxUniversalLocationLength> =
+			bounded_vec![1; 1];
 		assert_eq!(
 			AssetMetadataExtender::universal_location_extensions_counter(
 				another_universal_location
-			)
-			.unwrap(),
+			),
 			0
+		);
+
+		// create another extension for the same UL with another claimer
+		let another_claimer = H160::from_low_u64_be(1);
+		create_extension(another_claimer, universal_location.clone(), token_uri);
+		assert_eq!(
+			AssetMetadataExtender::universal_location_extensions_counter(universal_location),
+			2
 		);
 	});
 }
 
-// #[test]
-// fn when_updating_extension_index_does_not_increase() {
-// 	// test same claimer several times and same asset with several claimers
-// 	new_test_ext().execute_with(|| {});
-// }
-
 #[test]
-fn given_an_ul_i_can_get_all_its_token_uris() {
+fn given_an_ul_i_can_get_all_its_extensions() {
 	new_test_ext().execute_with(|| {
-		let universal_location = 0;
-		let token_uri = 1;
-		let claimer = 2;
-		let n = 2;
-		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
-		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+
+		let n = 1000;
 		for i in 0..n {
-			assert!(AssetMetadataExtender::universal_location_extensions(universal_location, i)
-				.is_some()); // TODO get the first field of the struct
+			let claimer = H160::from_low_u64_be(i);
+			create_extension(claimer, universal_location.clone(), token_uri.clone());
 		}
-	});
-}
 
-#[test]
-fn given_an_ul_i_can_get_all_its_claimers() {
-	new_test_ext().execute_with(|| {
-		let universal_location = 0;
-		let token_uri = 1;
-		let claimer = 2;
-		let n = 2;
-		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
-		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
 		for i in 0..n {
-			assert!(AssetMetadataExtender::universal_location_extensions(universal_location, i)
-				.is_some()); // TODO get the second field of the struct
+			assert_eq!(
+				AssetMetadataExtender::universal_location_extensions(universal_location.clone(), i)
+					.unwrap()
+					.token_uri,
+				token_uri
+			);
+			let expected_claimer = H160::from_low_u64_be(i);
+			assert_eq!(
+				AssetMetadataExtender::universal_location_extensions(universal_location.clone(), i)
+					.unwrap()
+					.claimer,
+				expected_claimer
+			);
 		}
 	});
 }
@@ -90,12 +121,13 @@ fn given_an_ul_i_can_get_all_its_claimers() {
 #[test]
 fn given_a_claimer_and_ul_i_can_get_the_extension() {
 	new_test_ext().execute_with(|| {
-		let universal_location = 0;
-		let token_uri = 1;
-		let claimer = 2;
-		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		let claimer = H160::zero();
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+
+		create_extension(claimer, universal_location.clone(), token_uri);
 		assert_eq!(
-			AssetMetadataExtender::claimer_extensions(claimer, universal_location).unwrap(),
+			AssetMetadataExtender::claimer_extensions(claimer, universal_location.clone()).unwrap(),
 			universal_location
 		);
 	});

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -48,7 +48,7 @@ fn given_an_ul_and_token_uri_i_cannot_create_twice_asset_extension_with_same_cla
 				universal_location,
 				token_uri
 			),
-			Error::<Test>::ExtensionAlreadyExists
+			Error::<Test>::MetadataExtensionAlreadyExists
 		);
 	});
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -33,7 +33,7 @@ fn create_metadata_extension_works() {
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 
 		System::assert_last_event(
-			Event::MetadataExtensionCreated { universal_location, claimer, token_uri }.into(),
+			Event::ExtensionCreated { universal_location, claimer, token_uri }.into(),
 		);
 	});
 }
@@ -52,7 +52,7 @@ fn claimer_cannot_create_multiple_extensions_per_ul() {
 				universal_location,
 				token_uri
 			),
-			Error::<Test>::MetadataExtensionAlreadyExists
+			Error::<Test>::ExtensionAlreadyExists
 		);
 	});
 }
@@ -65,57 +65,57 @@ fn create_metadata_extension_increases_counter() {
 		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
 		// create first extension for the given UL
-		assert_eq!(
-			AssetMetadataExtender::metadata_extensions_counter(universal_location.clone()),
-			0
-		);
+		assert_eq!(AssetMetadataExtender::extensions_counter(universal_location.clone()), 0);
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
-		assert_eq!(
-			AssetMetadataExtender::metadata_extensions_counter(universal_location.clone()),
-			1
-		);
+		assert_eq!(AssetMetadataExtender::extensions_counter(universal_location.clone()), 1);
 
 		// check that no other UL has been affected
 		let another_universal_location: UniversalLocationOf<Test> = bounded_vec![1; 1];
-		assert_eq!(
-			AssetMetadataExtender::metadata_extensions_counter(another_universal_location),
-			0
-		);
+		assert_eq!(AssetMetadataExtender::extensions_counter(another_universal_location), 0);
 
 		// create another extension for the same UL with another claimer
 		let another_claimer = H160::from_low_u64_be(1);
 		create_metadata_extension(another_claimer, universal_location.clone(), token_uri);
-		assert_eq!(AssetMetadataExtender::metadata_extensions_counter(universal_location), 2);
+		assert_eq!(AssetMetadataExtender::extensions_counter(universal_location), 2);
 	});
 }
 
 #[test]
-fn get_all_indexed_metadata_extensions_details() {
+fn get_all_token_uris_and_claimers_from_extensions_works() {
 	new_test_ext().execute_with(|| {
 		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
-		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
+		let token_uri_expected: TokenUriOf<Test> = bounded_vec![2; 10];
 
 		let n = 1000;
 		for i in 0..n {
 			let claimer = H160::from_low_u64_be(i);
-			create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
+			create_metadata_extension(
+				claimer,
+				universal_location.clone(),
+				token_uri_expected.clone(),
+			);
 		}
 
 		for i in 0..n {
-			let metadata_extension = AssetMetadataExtender::indexed_metadata_extensions(
+			let claimer = AssetMetadataExtender::claimers_by_location_and_index(
 				universal_location.clone(),
 				i as u32,
 			)
 			.unwrap();
-			assert_eq!(metadata_extension.token_uri, token_uri);
-			assert_eq!(metadata_extension.claimer, H160::from_low_u64_be(i));
+			let token_uri = AssetMetadataExtender::token_uris_by_claimer_and_location(
+				claimer.clone(),
+				universal_location.clone(),
+			)
+			.unwrap();
+			assert_eq!(token_uri, token_uri_expected);
+			assert_eq!(claimer, H160::from_low_u64_be(i));
 		}
 	});
 }
 
 #[test]
-fn get_metadata_extensions_works() {
+fn get_token_uris_by_claimer_and_location_works() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
 		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
@@ -123,8 +123,11 @@ fn get_metadata_extensions_works() {
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
-			AssetMetadataExtender::metadata_extensions(claimer, universal_location.clone())
-				.unwrap(),
+			AssetMetadataExtender::token_uris_by_claimer_and_location(
+				claimer,
+				universal_location.clone()
+			)
+			.unwrap(),
 			token_uri
 		);
 	});

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -1,14 +1,18 @@
-use crate::{mock::*, traits::AssetMetadataExtender as _, Error, Event};
+use crate::{
+	mock::*,
+	traits::AssetMetadataExtender as _,
+	types::{AccountIdOf, TokenUriOf, UniversalLocationOf},
+	Error, Event,
+};
 use frame_support::{assert_noop, assert_ok};
 use sp_core::{bounded_vec, H160};
-use sp_runtime::BoundedVec;
 
 // UL stands for Universal Location
 
 fn create_metadata_extension(
-	claimer: AccountId,
-	universal_location: UniversalLocation,
-	token_uri: TokenUri,
+	claimer: AccountIdOf<Test>,
+	universal_location: UniversalLocationOf<Test>,
+	token_uri: TokenUriOf<Test>,
 ) {
 	assert_ok!(AssetMetadataExtender::create_metadata_extension(
 		claimer,
@@ -23,8 +27,8 @@ fn create_metadata_extension_works() {
 		// Go past genesis block so events get deposited
 		System::set_block_number(1);
 		let claimer = H160::zero();
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 
@@ -38,8 +42,8 @@ fn create_metadata_extension_works() {
 fn claimer_cannot_create_multiple_extensions_per_ul() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_noop!(
@@ -57,8 +61,8 @@ fn claimer_cannot_create_multiple_extensions_per_ul() {
 fn create_metadata_extension_increases_counter() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
 		// create first extension for the given UL
 		assert_eq!(
@@ -73,8 +77,7 @@ fn create_metadata_extension_increases_counter() {
 		);
 
 		// check that no other UL has been affected
-		let another_universal_location: BoundedVec<u8, MaxUniversalLocationLength> =
-			bounded_vec![1; 1];
+		let another_universal_location: UniversalLocationOf<Test> = bounded_vec![1; 1];
 		assert_eq!(
 			AssetMetadataExtender::metadata_extensions_counter(another_universal_location),
 			0
@@ -90,8 +93,8 @@ fn create_metadata_extension_increases_counter() {
 #[test]
 fn get_all_indexed_metadata_extensions_details() {
 	new_test_ext().execute_with(|| {
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
 		let n = 1000;
 		for i in 0..n {
@@ -115,8 +118,8 @@ fn get_all_indexed_metadata_extensions_details() {
 fn claimer_token_uri_works() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -103,7 +103,7 @@ fn get_all_indexed_metadata_extensions_details() {
 		}
 
 		for i in 0..n {
-			let metadata_extension = AssetMetadataExtender::indexed_metadata_extensions_details(
+			let metadata_extension = AssetMetadataExtender::indexed_metadata_extensions(
 				universal_location.clone(),
 				i as u32,
 			)
@@ -115,7 +115,7 @@ fn get_all_indexed_metadata_extensions_details() {
 }
 
 #[test]
-fn claimer_token_uri_works() {
+fn get_metadata_extensions_works() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
 		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
@@ -123,7 +123,8 @@ fn claimer_token_uri_works() {
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
-			AssetMetadataExtender::claimer_token_uri(claimer, universal_location.clone()).unwrap(),
+			AssetMetadataExtender::metadata_extensions(claimer, universal_location.clone())
+				.unwrap(),
 			token_uri
 		);
 	});

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -54,7 +54,7 @@ fn claimer_cannot_create_multiple_extensions_per_ul() {
 }
 
 #[test]
-fn given_an_universal_location_after_creating_extension_counter_increases() {
+fn create_metadata_extension_increases_counter() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
 		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
@@ -112,7 +112,7 @@ fn given_an_ul_i_can_get_all_its_extensions() {
 }
 
 #[test]
-fn given_a_claimer_and_ul_i_can_get_the_extension() {
+fn claimer_token_uri_works() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
 		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -100,7 +100,7 @@ fn get_all_indexed_metadata_extensions() {
 		}
 
 		for i in 0..n {
-			let metadata_extension = AssetMetadataExtender::indexed_metadata_extensions(
+			let metadata_extension = AssetMetadataExtender::indexed_metadata_extensions_details(
 				universal_location.clone(),
 				i as u32,
 			)

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -18,7 +18,7 @@ fn create_metadata_extension(
 }
 
 #[test]
-fn given_an_ul_and_token_uri_i_can_create_asset_extension() {
+fn create_metadata_extension_works() {
 	new_test_ext().execute_with(|| {
 		// Go past genesis block so events get deposited
 		System::set_block_number(1);
@@ -35,7 +35,7 @@ fn given_an_ul_and_token_uri_i_can_create_asset_extension() {
 }
 
 #[test]
-fn given_an_ul_and_token_uri_i_cannot_create_twice_asset_extension_with_same_claimer() {
+fn claimer_cannot_create_multiple_extensions_per_ul() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
 		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -245,12 +245,12 @@ fn after_update_extension_counter_does_not_increase() {
 		let new_token_uri: TokenUriOf<Test> = bounded_vec![3; 10];
 
 		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
-		assert_eq!(AssetMetadataExtender::extensions_counter(universal_location.clone()), 0);
+		assert_eq!(AssetMetadataExtender::extensions_counter(universal_location.clone()), 1);
 		assert_ok!(AssetMetadataExtender::update_token_uri_extension(
 			claimer.clone(),
 			universal_location.clone(),
 			new_token_uri.clone()
 		));
-		assert_eq!(AssetMetadataExtender::extensions_counter(universal_location.clone()), 0);
+		assert_eq!(AssetMetadataExtender::extensions_counter(universal_location.clone()), 1);
 	});
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -5,12 +5,16 @@ use sp_runtime::BoundedVec;
 
 // UL stands for Universal Location
 
-fn create_extension(
+fn create_metadata_extension(
 	claimer: AccountId,
 	universal_location: UniversalLocation,
 	token_uri: TokenUri,
 ) {
-	assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+	assert_ok!(AssetMetadataExtender::create_metadata_extension(
+		claimer,
+		universal_location,
+		token_uri
+	));
 }
 
 #[test]
@@ -22,10 +26,10 @@ fn given_an_ul_and_token_uri_i_can_create_asset_extension() {
 		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
 		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
 
-		create_extension(claimer, universal_location.clone(), token_uri.clone());
+		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 
 		System::assert_last_event(
-			Event::ExtensionCreated { universal_location, claimer, token_uri }.into(),
+			Event::MetadataExtensionCreated { universal_location, claimer, token_uri }.into(),
 		);
 	});
 }
@@ -37,9 +41,13 @@ fn given_an_ul_and_token_uri_i_cannot_create_twice_asset_extension_with_same_cla
 		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
 		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
 
-		create_extension(claimer, universal_location.clone(), token_uri.clone());
+		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_noop!(
-			AssetMetadataExtender::create_extension(claimer, universal_location, token_uri),
+			AssetMetadataExtender::create_metadata_extension(
+				claimer,
+				universal_location,
+				token_uri
+			),
 			Error::<Test>::ExtensionAlreadyExists
 		);
 	});
@@ -54,17 +62,13 @@ fn given_an_universal_location_after_creating_extension_counter_increases() {
 
 		// create first extension for the given UL
 		assert_eq!(
-			AssetMetadataExtender::universal_location_extensions_counter(
-				universal_location.clone()
-			),
+			AssetMetadataExtender::asset_metadata_extensions_counter(universal_location.clone()),
 			0
 		);
 
-		create_extension(claimer, universal_location.clone(), token_uri.clone());
+		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
-			AssetMetadataExtender::universal_location_extensions_counter(
-				universal_location.clone()
-			),
+			AssetMetadataExtender::asset_metadata_extensions_counter(universal_location.clone()),
 			1
 		);
 
@@ -72,19 +76,14 @@ fn given_an_universal_location_after_creating_extension_counter_increases() {
 		let another_universal_location: BoundedVec<u8, MaxUniversalLocationLength> =
 			bounded_vec![1; 1];
 		assert_eq!(
-			AssetMetadataExtender::universal_location_extensions_counter(
-				another_universal_location
-			),
+			AssetMetadataExtender::asset_metadata_extensions_counter(another_universal_location),
 			0
 		);
 
 		// create another extension for the same UL with another claimer
 		let another_claimer = H160::from_low_u64_be(1);
-		create_extension(another_claimer, universal_location.clone(), token_uri);
-		assert_eq!(
-			AssetMetadataExtender::universal_location_extensions_counter(universal_location),
-			2
-		);
+		create_metadata_extension(another_claimer, universal_location.clone(), token_uri);
+		assert_eq!(AssetMetadataExtender::asset_metadata_extensions_counter(universal_location), 2);
 	});
 }
 
@@ -97,19 +96,19 @@ fn given_an_ul_i_can_get_all_its_extensions() {
 		let n = 1000;
 		for i in 0..n {
 			let claimer = H160::from_low_u64_be(i);
-			create_extension(claimer, universal_location.clone(), token_uri.clone());
+			create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		}
 
 		for i in 0..n {
 			assert_eq!(
-				AssetMetadataExtender::universal_location_extensions(universal_location.clone(), i)
+				AssetMetadataExtender::metadata_extensions(universal_location.clone(), i)
 					.unwrap()
 					.token_uri,
 				token_uri
 			);
 			let expected_claimer = H160::from_low_u64_be(i);
 			assert_eq!(
-				AssetMetadataExtender::universal_location_extensions(universal_location.clone(), i)
+				AssetMetadataExtender::metadata_extensions(universal_location.clone(), i)
 					.unwrap()
 					.claimer,
 				expected_claimer
@@ -125,9 +124,10 @@ fn given_a_claimer_and_ul_i_can_get_the_extension() {
 		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
 		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
 
-		create_extension(claimer, universal_location.clone(), token_uri);
+		create_metadata_extension(claimer, universal_location.clone(), token_uri);
 		assert_eq!(
-			AssetMetadataExtender::claimer_extensions(claimer, universal_location.clone()).unwrap(),
+			AssetMetadataExtender::claimer_metadata_extensions(claimer, universal_location.clone())
+				.unwrap(),
 			universal_location
 		);
 	});

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -120,8 +120,7 @@ fn given_a_claimer_and_ul_i_can_get_the_extension() {
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
-			AssetMetadataExtender::claimer_metadata_extensions(claimer, universal_location.clone())
-				.unwrap(),
+			AssetMetadataExtender::claimer_token_uri(claimer, universal_location.clone()).unwrap(),
 			token_uri
 		);
 	});

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -23,8 +23,8 @@ fn given_an_ul_and_token_uri_i_can_create_asset_extension() {
 		// Go past genesis block so events get deposited
 		System::set_block_number(1);
 		let claimer = H160::zero();
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 
@@ -38,8 +38,8 @@ fn given_an_ul_and_token_uri_i_can_create_asset_extension() {
 fn given_an_ul_and_token_uri_i_cannot_create_twice_asset_extension_with_same_claimer() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_noop!(
@@ -57,8 +57,8 @@ fn given_an_ul_and_token_uri_i_cannot_create_twice_asset_extension_with_same_cla
 fn given_an_universal_location_after_creating_extension_counter_increases() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
 
 		// create first extension for the given UL
 		assert_eq!(
@@ -90,8 +90,8 @@ fn given_an_universal_location_after_creating_extension_counter_increases() {
 #[test]
 fn given_an_ul_i_can_get_all_its_extensions() {
 	new_test_ext().execute_with(|| {
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
 
 		let n = 1000;
 		for i in 0..n {
@@ -101,16 +101,22 @@ fn given_an_ul_i_can_get_all_its_extensions() {
 
 		for i in 0..n {
 			assert_eq!(
-				AssetMetadataExtender::metadata_extensions(universal_location.clone(), i)
-					.unwrap()
-					.token_uri,
+				AssetMetadataExtender::indexed_metadata_extensions(
+					universal_location.clone(),
+					i as u32
+				)
+				.unwrap()
+				.token_uri,
 				token_uri
 			);
 			let expected_claimer = H160::from_low_u64_be(i);
 			assert_eq!(
-				AssetMetadataExtender::metadata_extensions(universal_location.clone(), i)
-					.unwrap()
-					.claimer,
+				AssetMetadataExtender::indexed_metadata_extensions(
+					universal_location.clone(),
+					i as u32
+				)
+				.unwrap()
+				.claimer,
 				expected_claimer
 			);
 		}
@@ -121,14 +127,14 @@ fn given_an_ul_i_can_get_all_its_extensions() {
 fn given_a_claimer_and_ul_i_can_get_the_extension() {
 	new_test_ext().execute_with(|| {
 		let claimer = H160::zero();
-		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![0; 1];
-		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![0; 1];
+		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
+		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];
 
-		create_metadata_extension(claimer, universal_location.clone(), token_uri);
+		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
 			AssetMetadataExtender::claimer_metadata_extensions(claimer, universal_location.clone())
 				.unwrap(),
-			universal_location
+			token_uri
 		);
 	});
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -88,7 +88,7 @@ fn create_metadata_extension_increases_counter() {
 }
 
 #[test]
-fn given_an_ul_i_can_get_all_its_extensions() {
+fn get_all_indexed_metadata_extensions() {
 	new_test_ext().execute_with(|| {
 		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
 		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -1,0 +1,102 @@
+use crate::{mock::*, traits::AssetMetadataExtender as _};
+use frame_support::assert_ok;
+
+// UL stands for Universal Location
+
+#[test]
+fn given_an_ul_and_token_uri_i_can_create_asset_extension() {
+	new_test_ext().execute_with(|| {
+		let universal_location = 0;
+		let token_uri = 1;
+		let claimer = 2;
+		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+
+		// TODO event is emmitted
+	});
+}
+
+// #[test]
+// fn given_an_ul_and_token_uri_i_can_update_an_existing_extension() {
+// 	new_test_ext().execute_with(|| {});
+// }
+
+#[test]
+fn given_a_universal_location_after_creating_extension_counter_increases() {
+	// TODO test same claimer several times and same asset with several claimers
+	new_test_ext().execute_with(|| {
+		let universal_location = 0;
+		let another_universal_location = 1;
+		let token_uri = 1;
+		let claimer = 2;
+		assert_eq!(
+			AssetMetadataExtender::universal_location_extensions_counter(universal_location)
+				.unwrap(),
+			0
+		);
+		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		assert_eq!(
+			AssetMetadataExtender::universal_location_extensions_counter(universal_location)
+				.unwrap(),
+			1
+		);
+		assert_eq!(
+			AssetMetadataExtender::universal_location_extensions_counter(
+				another_universal_location
+			)
+			.unwrap(),
+			0
+		);
+	});
+}
+
+// #[test]
+// fn when_updating_extension_index_does_not_increase() {
+// 	// test same claimer several times and same asset with several claimers
+// 	new_test_ext().execute_with(|| {});
+// }
+
+#[test]
+fn given_an_ul_i_can_get_all_its_token_uris() {
+	new_test_ext().execute_with(|| {
+		let universal_location = 0;
+		let token_uri = 1;
+		let claimer = 2;
+		let n = 2;
+		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		for i in 0..n {
+			assert!(AssetMetadataExtender::universal_location_extensions(universal_location, i)
+				.is_some()); // TODO get the first field of the struct
+		}
+	});
+}
+
+#[test]
+fn given_an_ul_i_can_get_all_its_claimers() {
+	new_test_ext().execute_with(|| {
+		let universal_location = 0;
+		let token_uri = 1;
+		let claimer = 2;
+		let n = 2;
+		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		for i in 0..n {
+			assert!(AssetMetadataExtender::universal_location_extensions(universal_location, i)
+				.is_some()); // TODO get the second field of the struct
+		}
+	});
+}
+
+#[test]
+fn given_a_claimer_and_ul_i_can_get_the_extension() {
+	new_test_ext().execute_with(|| {
+		let universal_location = 0;
+		let token_uri = 1;
+		let claimer = 2;
+		assert_ok!(AssetMetadataExtender::create_extension(claimer, universal_location, token_uri));
+		assert_eq!(
+			AssetMetadataExtender::claimer_extensions(claimer, universal_location).unwrap(),
+			universal_location
+		);
+	});
+}

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -62,13 +62,13 @@ fn given_an_universal_location_after_creating_extension_counter_increases() {
 
 		// create first extension for the given UL
 		assert_eq!(
-			AssetMetadataExtender::asset_metadata_extensions_counter(universal_location.clone()),
+			AssetMetadataExtender::metadata_extensions_counter(universal_location.clone()),
 			0
 		);
 
 		create_metadata_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
-			AssetMetadataExtender::asset_metadata_extensions_counter(universal_location.clone()),
+			AssetMetadataExtender::metadata_extensions_counter(universal_location.clone()),
 			1
 		);
 
@@ -76,14 +76,14 @@ fn given_an_universal_location_after_creating_extension_counter_increases() {
 		let another_universal_location: BoundedVec<u8, MaxUniversalLocationLength> =
 			bounded_vec![1; 1];
 		assert_eq!(
-			AssetMetadataExtender::asset_metadata_extensions_counter(another_universal_location),
+			AssetMetadataExtender::metadata_extensions_counter(another_universal_location),
 			0
 		);
 
 		// create another extension for the same UL with another claimer
 		let another_claimer = H160::from_low_u64_be(1);
 		create_metadata_extension(another_claimer, universal_location.clone(), token_uri);
-		assert_eq!(AssetMetadataExtender::asset_metadata_extensions_counter(universal_location), 2);
+		assert_eq!(AssetMetadataExtender::metadata_extensions_counter(universal_location), 2);
 	});
 }
 

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -100,25 +100,13 @@ fn given_an_ul_i_can_get_all_its_extensions() {
 		}
 
 		for i in 0..n {
-			assert_eq!(
-				AssetMetadataExtender::indexed_metadata_extensions(
-					universal_location.clone(),
-					i as u32
-				)
-				.unwrap()
-				.token_uri,
-				token_uri
-			);
-			let expected_claimer = H160::from_low_u64_be(i);
-			assert_eq!(
-				AssetMetadataExtender::indexed_metadata_extensions(
-					universal_location.clone(),
-					i as u32
-				)
-				.unwrap()
-				.claimer,
-				expected_claimer
-			);
+			let metadata_extension = AssetMetadataExtender::indexed_metadata_extensions(
+				universal_location.clone(),
+				i as u32,
+			)
+			.unwrap();
+			assert_eq!(metadata_extension.token_uri, token_uri);
+			assert_eq!(metadata_extension.claimer, H160::from_low_u64_be(i));
 		}
 	});
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -88,7 +88,7 @@ fn create_metadata_extension_increases_counter() {
 }
 
 #[test]
-fn get_all_indexed_metadata_extensions() {
+fn get_all_indexed_metadata_extensions_details() {
 	new_test_ext().execute_with(|| {
 		let universal_location: BoundedVec<u8, MaxUniversalLocationLength> = bounded_vec![1; 10];
 		let token_uri: BoundedVec<u8, MaxTokenUriLength> = bounded_vec![2; 10];

--- a/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
@@ -1,11 +1,15 @@
 use sp_runtime::DispatchResult;
 
+use crate::{
+	types::{AccountIdOf, TokenUriOf, UniversalLocationOf},
+	Config,
+};
+
 /// `AssetMetadataExtender` trait for managing asset metadata extensions
-pub trait AssetMetadataExtender<AccountId, TokenUri, UniversalLocation> {
-	/// Creates new asset metadata extension
+pub trait AssetMetadataExtender<T: Config> {
 	fn create_metadata_extension(
-		claimer: AccountId,
-		universal_location: UniversalLocation,
-		token_uri: TokenUri,
+		claimer: AccountIdOf<T>,
+		universal_location: UniversalLocationOf<T>,
+		token_uri: TokenUriOf<T>,
 	) -> DispatchResult;
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
@@ -1,4 +1,4 @@
-use sp_runtime::DispatchError;
+use sp_runtime::DispatchResult;
 
 /// `AssetMetadataExtender` trait for managing asset metadata extensions
 pub trait AssetMetadataExtender<AccountId, TokenUri, UniversalLocation> {
@@ -7,5 +7,5 @@ pub trait AssetMetadataExtender<AccountId, TokenUri, UniversalLocation> {
 		claimer: AccountId,
 		universal_location: UniversalLocation,
 		token_uri: TokenUri,
-	) -> Result<(), DispatchError>;
+	) -> DispatchResult;
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
@@ -1,0 +1,11 @@
+use sp_runtime::DispatchError;
+
+/// `AssetMetadataExtender` trait for managing asset extensions
+pub trait AssetMetadataExtender {
+	/// Creates new extension
+	fn create_extension(
+		claimer: u32,
+		universal_location: u32,
+		token_uri: u32,
+	) -> Result<(), DispatchError>;
+}

--- a/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
@@ -1,11 +1,11 @@
 use sp_runtime::DispatchError;
 
 /// `AssetMetadataExtender` trait for managing asset extensions
-pub trait AssetMetadataExtender {
+pub trait AssetMetadataExtender<AccountId, TokenUri, UniversalLocation> {
 	/// Creates new extension
 	fn create_extension(
-		claimer: u32,
-		universal_location: u32,
-		token_uri: u32,
+		claimer: AccountId,
+		universal_location: UniversalLocation,
+		token_uri: TokenUri,
 	) -> Result<(), DispatchError>;
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
@@ -7,7 +7,13 @@ use crate::{
 
 /// `AssetMetadataExtender` trait for managing asset metadata extensions
 pub trait AssetMetadataExtender<T: Config> {
-	fn create_metadata_extension(
+	fn create_token_uri_extension(
+		claimer: AccountIdOf<T>,
+		universal_location: UniversalLocationOf<T>,
+		token_uri: TokenUriOf<T>,
+	) -> DispatchResult;
+
+	fn update_token_uri_extension(
 		claimer: AccountIdOf<T>,
 		universal_location: UniversalLocationOf<T>,
 		token_uri: TokenUriOf<T>,

--- a/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
@@ -1,9 +1,9 @@
 use sp_runtime::DispatchError;
 
-/// `AssetMetadataExtender` trait for managing asset extensions
+/// `AssetMetadataExtender` trait for managing asset metadata extensions
 pub trait AssetMetadataExtender<AccountId, TokenUri, UniversalLocation> {
-	/// Creates new extension
-	fn create_extension(
+	/// Creates new asset metadata extension
+	fn create_metadata_extension(
 		claimer: AccountId,
 		universal_location: UniversalLocation,
 		token_uri: TokenUri,

--- a/ownership-chain/pallets/asset-metadata-extender/src/types.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/types.rs
@@ -13,9 +13,11 @@ pub type UniversalLocationOf<T> = BoundedVec<u8, <T as crate::Config>::MaxUniver
 /// of size N.
 pub type Index = u64;
 
+/// Asset metadata extension
+/// This will contain the claimer account and location in a raw form
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq, Eq, Clone)]
 #[scale_info(skip_type_params(T))]
-pub struct Extension<T: crate::Config> {
+pub struct MetadataExtension<T: crate::Config> {
 	pub claimer: AccountIdOf<T>,
 	pub token_uri: TokenUriOf<T>,
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/types.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/types.rs
@@ -1,6 +1,24 @@
 //! Types used in the pallet
-use sp_core::U256;
+use frame_support::pallet_prelude::*;
 use sp_runtime::BoundedVec;
 
-/// Wrapper around `BoundedVec` for `tokenUri`
+/// Wrapper around `BoundedVec` for `TokenUri`
 pub type TokenUriOf<T> = BoundedVec<u8, <T as crate::Config>::MaxTokenUriLength>;
+
+/// Wrapper around `BoundedVec` for `UniversalLocation`
+pub type UniversalLocationOf<T> = BoundedVec<u8, <T as crate::Config>::MaxUniversalLocationLength>;
+
+/// Serves as a position identifier for elements in a collection, facilitating iteration
+/// and element access. It corresponds to the element count, ranging from 0 to N-1 in a collection
+/// of size N.
+pub type Index = u64;
+
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq, Eq, Clone)]
+#[scale_info(skip_type_params(T))]
+pub struct Extension<T: crate::Config> {
+	pub claimer: AccountIdOf<T>,
+	pub token_uri: TokenUriOf<T>,
+}
+
+/// Explicit `AccountId`
+pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;

--- a/ownership-chain/pallets/asset-metadata-extender/src/types.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/types.rs
@@ -1,5 +1,4 @@
 //! Types used in the pallet
-use frame_support::pallet_prelude::*;
 use sp_runtime::BoundedVec;
 
 /// Wrapper around `BoundedVec` for `TokenUri`
@@ -12,15 +11,6 @@ pub type UniversalLocationOf<T> = BoundedVec<u8, <T as crate::Config>::MaxUniver
 /// and element access. It corresponds to the element count, ranging from 0 to N-1 in a collection
 /// of size N.
 pub type Index = u32;
-
-/// Asset metadata extension
-/// Contains the claimer account and token URI
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq, Eq, Clone)]
-#[scale_info(skip_type_params(T))]
-pub struct MetadataExtensionDetails<T: crate::Config> {
-	pub claimer: AccountIdOf<T>,
-	pub token_uri: TokenUriOf<T>,
-}
 
 /// Explicit `AccountId`
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;

--- a/ownership-chain/pallets/asset-metadata-extender/src/types.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/types.rs
@@ -14,7 +14,7 @@ pub type UniversalLocationOf<T> = BoundedVec<u8, <T as crate::Config>::MaxUniver
 pub type Index = u32;
 
 /// Asset metadata extension
-/// This will contain the claimer account and location in a raw form
+/// Contains the claimer account and token URI
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq, Eq, Clone)]
 #[scale_info(skip_type_params(T))]
 pub struct MetadataExtension<T: crate::Config> {

--- a/ownership-chain/pallets/asset-metadata-extender/src/types.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/types.rs
@@ -17,7 +17,7 @@ pub type Index = u32;
 /// Contains the claimer account and token URI
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq, Eq, Clone)]
 #[scale_info(skip_type_params(T))]
-pub struct MetadataExtension<T: crate::Config> {
+pub struct MetadataExtensionDetails<T: crate::Config> {
 	pub claimer: AccountIdOf<T>,
 	pub token_uri: TokenUriOf<T>,
 }

--- a/ownership-chain/pallets/asset-metadata-extender/src/types.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/types.rs
@@ -1,0 +1,6 @@
+//! Types used in the pallet
+use sp_core::U256;
+use sp_runtime::BoundedVec;
+
+/// Wrapper around `BoundedVec` for `tokenUri`
+pub type TokenUriOf<T> = BoundedVec<u8, <T as crate::Config>::MaxTokenUriLength>;

--- a/ownership-chain/pallets/asset-metadata-extender/src/types.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/types.rs
@@ -11,7 +11,7 @@ pub type UniversalLocationOf<T> = BoundedVec<u8, <T as crate::Config>::MaxUniver
 /// Serves as a position identifier for elements in a collection, facilitating iteration
 /// and element access. It corresponds to the element count, ranging from 0 to N-1 in a collection
 /// of size N.
-pub type Index = u64;
+pub type Index = u32;
 
 /// Asset metadata extension
 /// This will contain the claimer account and location in a raw form


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR introduces a new pallet `asset-metadata-extender` which allows for the creation of metadata extensions for a given asset location. The main changes include:
- The implementation of the `AssetMetadataExtender` trait in `lib.rs`, which provides a `create_metadata_extension` function.
- The definition of the pallet's storage items, events, and errors in `lib.rs`.
- The setup of a mock runtime environment for testing in `mock.rs`.
- The creation of unit tests for the pallet in `tests.rs`.
- The definition of types used in the pallet in `types.rs`.
- The package manifest for the pallet in `Cargo.toml`.


___

## Changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/src/lib.rs<br><br>

**This file contains the main logic for the new pallet <br>`asset-metadata-extender`. It includes the definition of the <br>pallet's storage items, events, errors, and the <br>implementation of the `AssetMetadataExtender` trait. The <br>pallet provides functionality to create metadata extensions <br>for a given asset location.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/272/files#diff-0b98d958eb954215a590ddfb8dfd04c42342b3e8b0a5edf43ef26a53da417602"> +132/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>traits.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/src/traits.rs<br><br>

**This file defines the `AssetMetadataExtender` trait which <br>includes the `create_metadata_extension` function.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/272/files#diff-fa633908831a73db8a43b25720fe973224d8b38c5b4840f88c65e3586deffb08"> +11/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/src/types.rs<br><br>

**This file defines types used in the <br>`asset-metadata-extender` pallet, including `TokenUriOf`, <br>`UniversalLocationOf`, `Index`, `MetadataExtension`, and <br>`AccountIdOf`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/272/files#diff-880d7d78cce7d1c6f223e00ced32b7803ec7601ff31bab86ec3fc0cb215e79ba"> +26/-0</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mock.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/src/mock.rs<br><br>

**This file sets up a mock runtime environment for testing the <br>`asset-metadata-extender` pallet. It includes the definition <br>of the `Test` runtime, parameter types, and a function to <br>build genesis storage for testing.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/272/files#diff-91fd671fa3194574f941f7236763560ab67b0cd5e67d9c30bd1e8828a80a60be"> +69/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tests.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/src/tests.rs<br><br>

**This file contains unit tests for the <br>`asset-metadata-extender` pallet. It tests the creation of <br>metadata extensions, the prevention of duplicate extensions <br>by the same claimer, and the retrieval of extensions.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/272/files#diff-d7cf71ea174fb578d9d86db7d2fe30f940d183fb80a7db5db8fe5c15da4d109d"> +134/-0</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/Cargo.toml<br><br>

**This file is the package manifest for the <br>`asset-metadata-extender` pallet. It includes the package <br>metadata, dependencies, features, and dev-dependencies.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/272/files#diff-f9ab8e6dd9337476f33108630312f94089fa13f19ca0d9d7e9dcb17254a90ae4"> +29/-0</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>