### PR TITLE
Fix `evolve` function to return an empty vector instead of token id

### DIFF
--- a/ownership-chain/e2e-tests/tests/test-evolution.ts
+++ b/ownership-chain/e2e-tests/tests/test-evolution.ts
@@ -1,150 +1,167 @@
-import { addressToCollectionId, createCollection, describeWithExistingNode, slotAndOwnerToTokenId } from "./util";
-import { GAS_LIMIT, GENESIS_ACCOUNT, SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI } from "./config";
-import { expect } from "chai";
-import Contract from "web3-eth-contract";
 import BN from "bn.js";
+import { expect } from "chai";
 import { step } from "mocha-steps";
+import Contract from "web3-eth-contract";
+import {
+	GAS_LIMIT,
+	GENESIS_ACCOUNT,
+	SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI,
+	SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI,
+} from "./config";
+import { addressToCollectionId, createCollection, describeWithExistingNode, slotAndOwnerToTokenId } from "./util";
 
 describeWithExistingNode("Frontier RPC (Mint and Evolve Assets)", (context) => {
-    let collectionId: BN;
-    let collectionContract: Contract
+	let collectionId: BN;
+	let collectionContract: Contract;
 
-    beforeEach(async function () {
-        this.timeout(70000);
+	beforeEach(async function () {
+		this.timeout(70000);
 
-        collectionContract = await createCollection(context);
-        collectionId = addressToCollectionId(collectionContract.options.address);
-    });
-    
-    step("when collection does not exist token uri should fail", async function () {
-        const tokenId = "0";
-        
-        try {
-            await collectionContract.methods.tokenURI(tokenId).call();
-            expect.fail("Expected error was not thrown"); // Ensure an error is thrown
-        } catch (error) {
-            expect(error.message).to.be.eq(
-                "Returned error: VM Exception while processing transaction: revert asset does not exist"
-            );
-        }
-    });
+		collectionContract = await createCollection(context);
+		collectionId = addressToCollectionId(collectionContract.options.address);
+	});
 
-    step("when asset is minted it should return token uri", async function () {
-        this.timeout(70000);
+	step("when collection does not exist token uri should fail", async function () {
+		const tokenId = "0";
 
-        const slot = "0";
-        const to = GENESIS_ACCOUNT;
-        const tokenURI = "https://example.com";
+		try {
+			await collectionContract.methods.tokenURI(tokenId).call();
+			expect.fail("Expected error was not thrown"); // Ensure an error is thrown
+		} catch (error) {
+			expect(error.message).to.be.eq(
+				"Returned error: VM Exception while processing transaction: revert asset does not exist"
+			);
+		}
+	});
 
-        let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
-        const result = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
-        expect(result.status).to.be.eq(true);
+	step("when asset is minted it should return token uri", async function () {
+		this.timeout(70000);
 
-        const tokenId = result.events.MintedWithExternalURI.returnValues._tokenId;
-        const got = await collectionContract.methods.tokenURI(tokenId).call();
-        expect(got).to.be.eq(tokenURI);
-    });
+		const slot = "0";
+		const to = GENESIS_ACCOUNT;
+		const tokenURI = "https://example.com";
 
-    step("given slot and owner it should return token id", async function () {
-        this.timeout(70000);
+		let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
+		const result = await collectionContract.methods
+			.mintWithExternalURI(to, slot, tokenURI)
+			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
+		expect(result.status).to.be.eq(true);
 
-        const slot = "1";
-        const to = GENESIS_ACCOUNT;
+		const tokenId = result.events.MintedWithExternalURI.returnValues._tokenId;
+		const got = await collectionContract.methods.tokenURI(tokenId).call();
+		expect(got).to.be.eq(tokenURI);
+	});
 
-        const tokenId = slotAndOwnerToTokenId(slot, to);
-        expect(tokenId).to.be.eq("000000000000000000000001c0f0f4ab324c46e55d02d0033343b4be8a55532d");
-        const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
-        expect(tokenIdDecimal).to.be.eq("2563001357829637001682277476112176020532353127213");
-    });
+	step("given slot and owner it should return token id", async function () {
+		this.timeout(70000);
 
-    step("when asset is minted it should emit an event", async function () {
-        this.timeout(70000);
+		const slot = "1";
+		const to = GENESIS_ACCOUNT;
 
-        const slot = "22";
-        const to = GENESIS_ACCOUNT;
-        const tokenURI = "https://example.com";
+		const tokenId = slotAndOwnerToTokenId(slot, to);
+		expect(tokenId).to.be.eq("000000000000000000000001c0f0f4ab324c46e55d02d0033343b4be8a55532d");
+		const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
+		expect(tokenIdDecimal).to.be.eq("2563001357829637001682277476112176020532353127213");
+	});
 
-        const result = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI)
-            .send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-        expect(result.status).to.be.eq(true);
+	step("when asset is minted it should emit an event", async function () {
+		this.timeout(70000);
 
-        expect(Object.keys(result.events).length).to.be.eq(1);
+		const slot = "22";
+		const to = GENESIS_ACCOUNT;
+		const tokenURI = "https://example.com";
 
-        // data returned within the event
-        expect(result.events.MintedWithExternalURI.returnValues._to).to.be.eq(to);
-        expect(result.events.MintedWithExternalURI.returnValues._slot).to.be.eq(slot);
-        expect(result.events.MintedWithExternalURI.returnValues._tokenURI).to.be.eq(tokenURI);
-        const tokenId = slotAndOwnerToTokenId(slot, to);
-        const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
-        expect(result.events.MintedWithExternalURI.returnValues._tokenId).to.be.eq(tokenIdDecimal);
+		const result = await collectionContract.methods
+			.mintWithExternalURI(to, slot, tokenURI)
+			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+		expect(result.status).to.be.eq(true);
 
-        // event topics
-        expect(result.events.MintedWithExternalURI.raw.topics.length).to.be.eq(2);
-        expect(result.events.MintedWithExternalURI.raw.topics[0]).to.be.eq(SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI);
-        expect(result.events.MintedWithExternalURI.raw.topics[1]).to.be.eq(context.web3.utils.padLeft(GENESIS_ACCOUNT.toLowerCase(), 64));
+		expect(Object.keys(result.events).length).to.be.eq(1);
 
-        // event data
-        expect(result.events.MintedWithExternalURI.raw.data).to.be.eq(
-            context.web3.eth.abi.encodeParameters(
-                ["uint96", "uint256", "string"],
-                [slot, tokenIdDecimal, tokenURI]
-            )
-        );
-    });
+		// data returned within the event
+		expect(result.events.MintedWithExternalURI.returnValues._to).to.be.eq(to);
+		expect(result.events.MintedWithExternalURI.returnValues._slot).to.be.eq(slot);
+		expect(result.events.MintedWithExternalURI.returnValues._tokenURI).to.be.eq(tokenURI);
+		const tokenId = slotAndOwnerToTokenId(slot, to);
+		const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
+		expect(result.events.MintedWithExternalURI.returnValues._tokenId).to.be.eq(tokenIdDecimal);
 
-    step("when asset is evolved it should change token uri", async function () {
-        this.timeout(70000);
+		// event topics
+		expect(result.events.MintedWithExternalURI.raw.topics.length).to.be.eq(2);
+		expect(result.events.MintedWithExternalURI.raw.topics[0]).to.be.eq(SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI);
+		expect(result.events.MintedWithExternalURI.raw.topics[1]).to.be.eq(
+			context.web3.utils.padLeft(GENESIS_ACCOUNT.toLowerCase(), 64)
+		);
 
-        const slot = "22";
-        const to = GENESIS_ACCOUNT;
-        const tokenURI = "https://example.com";
-        const newTokenURI = "https://new_example.com";
-        const tokenId = slotAndOwnerToTokenId(slot, to);
-        const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
+		// event data
+		expect(result.events.MintedWithExternalURI.raw.data).to.be.eq(
+			context.web3.eth.abi.encodeParameters(["uint96", "uint256", "string"], [slot, tokenIdDecimal, tokenURI])
+		);
+	});
 
-        const mintingResult = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-        expect(mintingResult.status).to.be.eq(true);
+	step("when asset is evolved it should change token uri", async function () {
+		this.timeout(70000);
 
-        const evolvingResult = await collectionContract.methods.evolveWithExternalURI(tokenIdDecimal, newTokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-        expect(evolvingResult.status).to.be.eq(true);
+		const slot = "22";
+		const to = GENESIS_ACCOUNT;
+		const tokenURI = "https://example.com";
+		const newTokenURI = "https://new_example.com";
+		const tokenId = slotAndOwnerToTokenId(slot, to);
+		const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
 
-        const got = await collectionContract.methods.tokenURI(tokenIdDecimal).call();
-        expect(got).to.be.eq(newTokenURI);
-    });
+		const mintingResult = await collectionContract.methods
+			.mintWithExternalURI(to, slot, tokenURI)
+			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+		expect(mintingResult.status).to.be.eq(true);
 
-    step("when asset is evolved it should emit an event", async function () {
-        this.timeout(70000);
+		const evolvingResult = await collectionContract.methods
+			.evolveWithExternalURI(tokenIdDecimal, newTokenURI)
+			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+		expect(evolvingResult.status).to.be.eq(true);
 
-        const slot = "22";
-        const to = GENESIS_ACCOUNT;
-        const tokenURI = "https://example.com";
-        const newTokenURI = "https://new_example.com";
-        const tokenId = slotAndOwnerToTokenId(slot, to);
-        const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
+		// returns nothing, i.e void
+		expect(evolvingResult).to.be.empty;
 
-        const mintingResult = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-        expect(mintingResult.status).to.be.eq(true);
+		const got = await collectionContract.methods.tokenURI(tokenIdDecimal).call();
+		expect(got).to.be.eq(newTokenURI);
+	});
 
-        const evolvingResult = await collectionContract.methods.evolveWithExternalURI(tokenIdDecimal, newTokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-        expect(evolvingResult.status).to.be.eq(true);
+	step("when asset is evolved it should emit an event", async function () {
+		this.timeout(70000);
 
-        expect(Object.keys(evolvingResult.events).length).to.be.eq(1);
+		const slot = "22";
+		const to = GENESIS_ACCOUNT;
+		const tokenURI = "https://example.com";
+		const newTokenURI = "https://new_example.com";
+		const tokenId = slotAndOwnerToTokenId(slot, to);
+		const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
 
-        // data returned within the event
-        expect(evolvingResult.events.EvolvedWithExternalURI.returnValues._tokenId).to.be.eq(tokenIdDecimal);
-        expect(evolvingResult.events.EvolvedWithExternalURI.returnValues._tokenURI).to.be.eq(newTokenURI);
+		const mintingResult = await collectionContract.methods
+			.mintWithExternalURI(to, slot, tokenURI)
+			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+		expect(mintingResult.status).to.be.eq(true);
 
-        // event topics
-        expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics.length).to.be.eq(2);
-        expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics[0]).to.be.eq(SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI);
-        expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics[1]).to.be.eq("0x" + tokenId);
+		const evolvingResult = await collectionContract.methods
+			.evolveWithExternalURI(tokenIdDecimal, newTokenURI)
+			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+		expect(evolvingResult.status).to.be.eq(true);
 
-        // event data
-        expect(evolvingResult.events.EvolvedWithExternalURI.raw.data).to.be.eq(
-            context.web3.eth.abi.encodeParameters(
-                ["string"],
-                [newTokenURI]
-            )
-        );
-    });
+		expect(Object.keys(evolvingResult.events).length).to.be.eq(1);
+
+		// data returned within the event
+		expect(evolvingResult.events.EvolvedWithExternalURI.returnValues._tokenId).to.be.eq(tokenIdDecimal);
+		expect(evolvingResult.events.EvolvedWithExternalURI.returnValues._tokenURI).to.be.eq(newTokenURI);
+
+		// event topics
+		expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics.length).to.be.eq(2);
+		expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics[0]).to.be.eq(
+			SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI
+		);
+		expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics[1]).to.be.eq("0x" + tokenId);
+
+		// event data
+		expect(evolvingResult.events.EvolvedWithExternalURI.raw.data).to.be.eq(
+			context.web3.eth.abi.encodeParameters(["string"], [newTokenURI])
+		);
+	});
 });

--- a/ownership-chain/e2e-tests/tests/test-evolution.ts
+++ b/ownership-chain/e2e-tests/tests/test-evolution.ts
@@ -1,167 +1,150 @@
-import BN from "bn.js";
-import { expect } from "chai";
-import { step } from "mocha-steps";
-import Contract from "web3-eth-contract";
-import {
-	GAS_LIMIT,
-	GENESIS_ACCOUNT,
-	SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI,
-	SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI,
-} from "./config";
 import { addressToCollectionId, createCollection, describeWithExistingNode, slotAndOwnerToTokenId } from "./util";
+import { GAS_LIMIT, GENESIS_ACCOUNT, SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI } from "./config";
+import { expect } from "chai";
+import Contract from "web3-eth-contract";
+import BN from "bn.js";
+import { step } from "mocha-steps";
 
 describeWithExistingNode("Frontier RPC (Mint and Evolve Assets)", (context) => {
-	let collectionId: BN;
-	let collectionContract: Contract;
+    let collectionId: BN;
+    let collectionContract: Contract
 
-	beforeEach(async function () {
-		this.timeout(70000);
+    beforeEach(async function () {
+        this.timeout(70000);
 
-		collectionContract = await createCollection(context);
-		collectionId = addressToCollectionId(collectionContract.options.address);
-	});
+        collectionContract = await createCollection(context);
+        collectionId = addressToCollectionId(collectionContract.options.address);
+    });
+    
+    step("when collection does not exist token uri should fail", async function () {
+        const tokenId = "0";
+        
+        try {
+            await collectionContract.methods.tokenURI(tokenId).call();
+            expect.fail("Expected error was not thrown"); // Ensure an error is thrown
+        } catch (error) {
+            expect(error.message).to.be.eq(
+                "Returned error: VM Exception while processing transaction: revert asset does not exist"
+            );
+        }
+    });
 
-	step("when collection does not exist token uri should fail", async function () {
-		const tokenId = "0";
+    step("when asset is minted it should return token uri", async function () {
+        this.timeout(70000);
 
-		try {
-			await collectionContract.methods.tokenURI(tokenId).call();
-			expect.fail("Expected error was not thrown"); // Ensure an error is thrown
-		} catch (error) {
-			expect(error.message).to.be.eq(
-				"Returned error: VM Exception while processing transaction: revert asset does not exist"
-			);
-		}
-	});
+        const slot = "0";
+        const to = GENESIS_ACCOUNT;
+        const tokenURI = "https://example.com";
 
-	step("when asset is minted it should return token uri", async function () {
-		this.timeout(70000);
+        let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
+        const result = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
+        expect(result.status).to.be.eq(true);
 
-		const slot = "0";
-		const to = GENESIS_ACCOUNT;
-		const tokenURI = "https://example.com";
+        const tokenId = result.events.MintedWithExternalURI.returnValues._tokenId;
+        const got = await collectionContract.methods.tokenURI(tokenId).call();
+        expect(got).to.be.eq(tokenURI);
+    });
 
-		let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
-		const result = await collectionContract.methods
-			.mintWithExternalURI(to, slot, tokenURI)
-			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT, nonce: nonce++ });
-		expect(result.status).to.be.eq(true);
+    step("given slot and owner it should return token id", async function () {
+        this.timeout(70000);
 
-		const tokenId = result.events.MintedWithExternalURI.returnValues._tokenId;
-		const got = await collectionContract.methods.tokenURI(tokenId).call();
-		expect(got).to.be.eq(tokenURI);
-	});
+        const slot = "1";
+        const to = GENESIS_ACCOUNT;
 
-	step("given slot and owner it should return token id", async function () {
-		this.timeout(70000);
+        const tokenId = slotAndOwnerToTokenId(slot, to);
+        expect(tokenId).to.be.eq("000000000000000000000001c0f0f4ab324c46e55d02d0033343b4be8a55532d");
+        const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
+        expect(tokenIdDecimal).to.be.eq("2563001357829637001682277476112176020532353127213");
+    });
 
-		const slot = "1";
-		const to = GENESIS_ACCOUNT;
+    step("when asset is minted it should emit an event", async function () {
+        this.timeout(70000);
 
-		const tokenId = slotAndOwnerToTokenId(slot, to);
-		expect(tokenId).to.be.eq("000000000000000000000001c0f0f4ab324c46e55d02d0033343b4be8a55532d");
-		const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
-		expect(tokenIdDecimal).to.be.eq("2563001357829637001682277476112176020532353127213");
-	});
+        const slot = "22";
+        const to = GENESIS_ACCOUNT;
+        const tokenURI = "https://example.com";
 
-	step("when asset is minted it should emit an event", async function () {
-		this.timeout(70000);
+        const result = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI)
+            .send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+        expect(result.status).to.be.eq(true);
 
-		const slot = "22";
-		const to = GENESIS_ACCOUNT;
-		const tokenURI = "https://example.com";
+        expect(Object.keys(result.events).length).to.be.eq(1);
 
-		const result = await collectionContract.methods
-			.mintWithExternalURI(to, slot, tokenURI)
-			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-		expect(result.status).to.be.eq(true);
+        // data returned within the event
+        expect(result.events.MintedWithExternalURI.returnValues._to).to.be.eq(to);
+        expect(result.events.MintedWithExternalURI.returnValues._slot).to.be.eq(slot);
+        expect(result.events.MintedWithExternalURI.returnValues._tokenURI).to.be.eq(tokenURI);
+        const tokenId = slotAndOwnerToTokenId(slot, to);
+        const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
+        expect(result.events.MintedWithExternalURI.returnValues._tokenId).to.be.eq(tokenIdDecimal);
 
-		expect(Object.keys(result.events).length).to.be.eq(1);
+        // event topics
+        expect(result.events.MintedWithExternalURI.raw.topics.length).to.be.eq(2);
+        expect(result.events.MintedWithExternalURI.raw.topics[0]).to.be.eq(SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI);
+        expect(result.events.MintedWithExternalURI.raw.topics[1]).to.be.eq(context.web3.utils.padLeft(GENESIS_ACCOUNT.toLowerCase(), 64));
 
-		// data returned within the event
-		expect(result.events.MintedWithExternalURI.returnValues._to).to.be.eq(to);
-		expect(result.events.MintedWithExternalURI.returnValues._slot).to.be.eq(slot);
-		expect(result.events.MintedWithExternalURI.returnValues._tokenURI).to.be.eq(tokenURI);
-		const tokenId = slotAndOwnerToTokenId(slot, to);
-		const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
-		expect(result.events.MintedWithExternalURI.returnValues._tokenId).to.be.eq(tokenIdDecimal);
+        // event data
+        expect(result.events.MintedWithExternalURI.raw.data).to.be.eq(
+            context.web3.eth.abi.encodeParameters(
+                ["uint96", "uint256", "string"],
+                [slot, tokenIdDecimal, tokenURI]
+            )
+        );
+    });
 
-		// event topics
-		expect(result.events.MintedWithExternalURI.raw.topics.length).to.be.eq(2);
-		expect(result.events.MintedWithExternalURI.raw.topics[0]).to.be.eq(SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI);
-		expect(result.events.MintedWithExternalURI.raw.topics[1]).to.be.eq(
-			context.web3.utils.padLeft(GENESIS_ACCOUNT.toLowerCase(), 64)
-		);
+    step("when asset is evolved it should change token uri", async function () {
+        this.timeout(70000);
 
-		// event data
-		expect(result.events.MintedWithExternalURI.raw.data).to.be.eq(
-			context.web3.eth.abi.encodeParameters(["uint96", "uint256", "string"], [slot, tokenIdDecimal, tokenURI])
-		);
-	});
+        const slot = "22";
+        const to = GENESIS_ACCOUNT;
+        const tokenURI = "https://example.com";
+        const newTokenURI = "https://new_example.com";
+        const tokenId = slotAndOwnerToTokenId(slot, to);
+        const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
 
-	step("when asset is evolved it should change token uri", async function () {
-		this.timeout(70000);
+        const mintingResult = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+        expect(mintingResult.status).to.be.eq(true);
 
-		const slot = "22";
-		const to = GENESIS_ACCOUNT;
-		const tokenURI = "https://example.com";
-		const newTokenURI = "https://new_example.com";
-		const tokenId = slotAndOwnerToTokenId(slot, to);
-		const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
+        const evolvingResult = await collectionContract.methods.evolveWithExternalURI(tokenIdDecimal, newTokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+        expect(evolvingResult.status).to.be.eq(true);
 
-		const mintingResult = await collectionContract.methods
-			.mintWithExternalURI(to, slot, tokenURI)
-			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-		expect(mintingResult.status).to.be.eq(true);
+        const got = await collectionContract.methods.tokenURI(tokenIdDecimal).call();
+        expect(got).to.be.eq(newTokenURI);
+    });
 
-		const evolvingResult = await collectionContract.methods
-			.evolveWithExternalURI(tokenIdDecimal, newTokenURI)
-			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-		expect(evolvingResult.status).to.be.eq(true);
+    step("when asset is evolved it should emit an event", async function () {
+        this.timeout(70000);
 
-		// returns nothing, i.e void
-		expect(evolvingResult).to.be.empty;
+        const slot = "22";
+        const to = GENESIS_ACCOUNT;
+        const tokenURI = "https://example.com";
+        const newTokenURI = "https://new_example.com";
+        const tokenId = slotAndOwnerToTokenId(slot, to);
+        const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
 
-		const got = await collectionContract.methods.tokenURI(tokenIdDecimal).call();
-		expect(got).to.be.eq(newTokenURI);
-	});
+        const mintingResult = await collectionContract.methods.mintWithExternalURI(to, slot, tokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+        expect(mintingResult.status).to.be.eq(true);
 
-	step("when asset is evolved it should emit an event", async function () {
-		this.timeout(70000);
+        const evolvingResult = await collectionContract.methods.evolveWithExternalURI(tokenIdDecimal, newTokenURI).send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
+        expect(evolvingResult.status).to.be.eq(true);
 
-		const slot = "22";
-		const to = GENESIS_ACCOUNT;
-		const tokenURI = "https://example.com";
-		const newTokenURI = "https://new_example.com";
-		const tokenId = slotAndOwnerToTokenId(slot, to);
-		const tokenIdDecimal = new BN(tokenId, 16, "be").toString(10);
+        expect(Object.keys(evolvingResult.events).length).to.be.eq(1);
 
-		const mintingResult = await collectionContract.methods
-			.mintWithExternalURI(to, slot, tokenURI)
-			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-		expect(mintingResult.status).to.be.eq(true);
+        // data returned within the event
+        expect(evolvingResult.events.EvolvedWithExternalURI.returnValues._tokenId).to.be.eq(tokenIdDecimal);
+        expect(evolvingResult.events.EvolvedWithExternalURI.returnValues._tokenURI).to.be.eq(newTokenURI);
 
-		const evolvingResult = await collectionContract.methods
-			.evolveWithExternalURI(tokenIdDecimal, newTokenURI)
-			.send({ from: GENESIS_ACCOUNT, gas: GAS_LIMIT });
-		expect(evolvingResult.status).to.be.eq(true);
+        // event topics
+        expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics.length).to.be.eq(2);
+        expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics[0]).to.be.eq(SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI);
+        expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics[1]).to.be.eq("0x" + tokenId);
 
-		expect(Object.keys(evolvingResult.events).length).to.be.eq(1);
-
-		// data returned within the event
-		expect(evolvingResult.events.EvolvedWithExternalURI.returnValues._tokenId).to.be.eq(tokenIdDecimal);
-		expect(evolvingResult.events.EvolvedWithExternalURI.returnValues._tokenURI).to.be.eq(newTokenURI);
-
-		// event topics
-		expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics.length).to.be.eq(2);
-		expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics[0]).to.be.eq(
-			SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI
-		);
-		expect(evolvingResult.events.EvolvedWithExternalURI.raw.topics[1]).to.be.eq("0x" + tokenId);
-
-		// event data
-		expect(evolvingResult.events.EvolvedWithExternalURI.raw.data).to.be.eq(
-			context.web3.eth.abi.encodeParameters(["string"], [newTokenURI])
-		);
-	});
+        // event data
+        expect(evolvingResult.events.EvolvedWithExternalURI.raw.data).to.be.eq(
+            context.web3.eth.abi.encodeParameters(
+                ["string"],
+                [newTokenURI]
+            )
+        );
+    });
 });

--- a/ownership-chain/precompile/evolution-collection/contracts/EvolutionCollection.sol
+++ b/ownership-chain/precompile/evolution-collection/contracts/EvolutionCollection.sol
@@ -56,5 +56,5 @@ interface EvolutionCollection {
     function evolveWithExternalURI(
         uint256 _tokenId,
         string calldata _tokenURI
-    ) external returns (uint256);
+    ) external;
 }

--- a/ownership-chain/precompile/evolution-collection/src/lib.rs
+++ b/ownership-chain/precompile/evolution-collection/src/lib.rs
@@ -210,7 +210,7 @@ where
 				// TODO: Add `ref_time` when precompiles are benchmarked
 				handle.record_external_cost(None, Some(consumed_weight.proof_size()))?;
 
-				Ok(succeed(EvmDataWriter::new().write(token_id).build()))
+				Ok(succeed(vec![]))
 			},
 			Err(err) => Err(revert_dispatch_error(err)),
 		}

--- a/ownership-chain/precompile/evolution-collection/src/lib.rs
+++ b/ownership-chain/precompile/evolution-collection/src/lib.rs
@@ -210,7 +210,7 @@ where
 				// TODO: Add `ref_time` when precompiles are benchmarked
 				handle.record_external_cost(None, Some(consumed_weight.proof_size()))?;
 
-				Ok(succeed(vec![]))
+				Ok(succeed(sp_std::vec![]))
 			},
 			Err(err) => Err(revert_dispatch_error(err)),
 		}

--- a/ownership-chain/precompile/evolution-collection/src/tests.rs
+++ b/ownership-chain/precompile/evolution-collection/src/tests.rs
@@ -287,7 +287,7 @@ fn evolve_works() {
 
 		precompiles()
 			.prepare_test(alice, collection_address, input)
-			.execute_returns(token_id);
+			.execute_returns_raw(vec![]);
 	});
 }
 


### PR DESCRIPTION
## Type
bug_fix


___

## Description
This PR addresses a bug in the `evolve` function of the `evolution-collection` precompile. Previously, this function returned a token id, but it has been updated to return an empty vector instead. The corresponding test, `evolve_works`, has also been updated to expect this new return value.


___

## Changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/evolution-collection/src/lib.rs<br><br>

**The `evolve` function has been modified to return an empty <br>vector instead of a token id.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/273/files#diff-226dbc8d8b24203a2bf2dc68997bf410f845992128754b81e4e30615ab4ac0ee"> +1/-1</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/evolution-collection/src/tests.rs<br><br>

**The test `evolve_works` has been updated to reflect the <br>change in the `evolve` function. It now expects an empty <br>vector as a return value instead of a token id.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/273/files#diff-1d737a09695f0303307ccdc6d8e28354d038c837d79c4327406dae465400790d"> +1/-1</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>