### PR TITLE
Addition of New Bootnode to Giedi Chain Configuration

### DIFF
--- a/ownership-chain/specs/giedi.raw.json
+++ b/ownership-chain/specs/giedi.raw.json
@@ -3,6 +3,7 @@
   "id": "giedi_chain",
   "chainType": "Live",
   "bootNodes": [
+    "/dns4/giedi-boot-1.gorengine.com/tcp/30334/p2p/12D3KooWR3UsCUm33oNtCWqEJ3EyzP1haodZxhqgQcLZwf68Nt7V"
   ],
   "telemetryEndpoints": null,
   "protocolId": "giedi_chain",


### PR DESCRIPTION
## Type
enhancement


___

## Description
- Added a new bootnode to the `giedi_chain` configuration in the `ownership-chain/specs/giedi.raw.json` file.


___

## Changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>giedi.raw.json&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/specs/giedi.raw.json<br><br>

**A new bootnode has been added to the `giedi_chain` <br>configuration.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/274/files#diff-f171d4bbbe944f3663ec5b14ea75cb37e42a60453948d7aac948c9d79c0f500e"> +1/-0</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>