### PR TITLE
Add new functions to retrieve and check token URI extensions by claimer and universal location

### DIFF
--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -175,6 +175,17 @@ impl<T: Config> AssetMetadataExtender<T> for Pallet<T> {
 		let claimer = Self::claimer_by_index(universal_location.clone(), index)?;
 		TokenUrisByClaimerAndLocation::<T>::get(claimer, universal_location)
 	}
+
+	fn extension_by_location_and_claimer(
+		claimer: AccountIdOf<T>,
+		universal_location: UniversalLocationOf<T>,
+	) -> Option<TokenUriOf<T>> {
+		TokenUrisByClaimerAndLocation::<T>::get(claimer, universal_location)
+	}
+
+	fn has_extension(universal_location: UniversalLocationOf<T>, claimer: AccountIdOf<T>) -> bool {
+		TokenUrisByClaimerAndLocation::<T>::contains_key(claimer, universal_location)
+	}
 }
 
 #[cfg(test)]

--- a/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/lib.rs
@@ -177,8 +177,8 @@ impl<T: Config> AssetMetadataExtender<T> for Pallet<T> {
 	}
 
 	fn extension_by_location_and_claimer(
-		claimer: AccountIdOf<T>,
 		universal_location: UniversalLocationOf<T>,
+		claimer: AccountIdOf<T>,
 	) -> Option<TokenUriOf<T>> {
 		TokenUrisByClaimerAndLocation::<T>::get(claimer, universal_location)
 	}

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -366,7 +366,7 @@ fn has_extension_should_return_true_if_it_exists() {
 		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
 		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
-		assert_eq!(AssetMetadataExtender::has_extension(universal_location, claimer), true);
+		assert!(AssetMetadataExtender::has_extension(universal_location, claimer));
 	});
 }
 

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -322,3 +322,60 @@ fn token_uri_extension_by_index_works() {
 		}
 	});
 }
+
+#[test]
+fn get_unexistent_extension_by_location_and_claimer_fails() {
+	new_test_ext().execute_with(|| {
+		let claimer = H160::zero();
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+
+		assert_eq!(
+			AssetMetadataExtender::extension_by_location_and_claimer(
+				claimer.clone(),
+				universal_location.clone()
+			),
+			None
+		);
+	});
+}
+
+#[test]
+fn get_extension_by_location_and_claimer_works() {
+	new_test_ext().execute_with(|| {
+		let claimer = H160::zero();
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
+
+		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
+		assert_eq!(
+			AssetMetadataExtender::extension_by_location_and_claimer(
+				claimer.clone(),
+				universal_location.clone()
+			)
+			.unwrap(),
+			token_uri
+		);
+	});
+}
+
+#[test]
+fn has_extension_should_return_true_if_it_exists() {
+	new_test_ext().execute_with(|| {
+		let claimer = H160::zero();
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
+
+		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
+		assert_eq!(AssetMetadataExtender::has_extension(universal_location, claimer), true);
+	});
+}
+
+#[test]
+fn has_extension_should_return_false_if_it_does_not_exist() {
+	new_test_ext().execute_with(|| {
+		let claimer = H160::zero();
+		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
+
+		assert_eq!(AssetMetadataExtender::has_extension(universal_location, claimer), false);
+	});
+}

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -331,8 +331,8 @@ fn get_unexistent_extension_by_location_and_claimer_fails() {
 
 		assert_eq!(
 			AssetMetadataExtender::extension_by_location_and_claimer(
-				claimer.clone(),
 				universal_location.clone()
+				claimer.clone(),
 			),
 			None
 		);
@@ -349,8 +349,8 @@ fn get_extension_by_location_and_claimer_works() {
 		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
 		assert_eq!(
 			AssetMetadataExtender::extension_by_location_and_claimer(
-				claimer.clone(),
 				universal_location.clone()
+				claimer.clone(),
 			)
 			.unwrap(),
 			token_uri

--- a/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/tests.rs
@@ -331,8 +331,8 @@ fn get_unexistent_extension_by_location_and_claimer_fails() {
 
 		assert_eq!(
 			AssetMetadataExtender::extension_by_location_and_claimer(
-				universal_location.clone()
-				claimer.clone(),
+				universal_location.clone(),
+				claimer.clone()
 			),
 			None
 		);
@@ -349,8 +349,8 @@ fn get_extension_by_location_and_claimer_works() {
 		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
 		assert_eq!(
 			AssetMetadataExtender::extension_by_location_and_claimer(
-				universal_location.clone()
-				claimer.clone(),
+				universal_location.clone(),
+				claimer.clone()
 			)
 			.unwrap(),
 			token_uri

--- a/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
@@ -38,8 +38,8 @@ pub trait AssetMetadataExtender<T: Config> {
 
 	/// Retrieves the token URI extension based on the claimer and universal location.
 	fn extension_by_location_and_claimer(
-		claimer: AccountIdOf<T>,
 		universal_location: UniversalLocationOf<T>,
+		claimer: AccountIdOf<T>,
 	) -> Option<TokenUriOf<T>>;
 
 	/// Checks if a token URI extension exists for the given universal location and claimer.

--- a/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
+++ b/ownership-chain/pallets/asset-metadata-extender/src/traits.rs
@@ -35,4 +35,13 @@ pub trait AssetMetadataExtender<T: Config> {
 		universal_location: UniversalLocationOf<T>,
 		index: u32,
 	) -> Option<TokenUriOf<T>>;
+
+	/// Retrieves the token URI extension based on the claimer and universal location.
+	fn extension_by_location_and_claimer(
+		claimer: AccountIdOf<T>,
+		universal_location: UniversalLocationOf<T>,
+	) -> Option<TokenUriOf<T>>;
+
+	/// Checks if a token URI extension exists for the given universal location and claimer.
+	fn has_extension(universal_location: UniversalLocationOf<T>, claimer: AccountIdOf<T>) -> bool;
 }

--- a/ownership-chain/precompile/asset-metadata-extender/contracts/AssetMetadataExtender.sol
+++ b/ownership-chain/precompile/asset-metadata-extender/contracts/AssetMetadataExtender.sol
@@ -71,19 +71,20 @@ interface AssetMetadataExtender {
         uint32 index
     ) external view returns (string memory);
 
-    /// @notice Retrieves the extension of a token's universal location by a claimer
-    /// @param _universalLocation Universal location of the token
-    /// @param _claimer Address of the claimer
-    /// @return Extension of the token's universal location
+    /// @notice Returns the extension of a Universal Location made by a claimer
+    /// @dev Reverts if the Universal Location has no extension by the provided claimer
+    /// @param _universalLocation The Universal Location
+    /// @param _claimer The address of the claimer
+    /// @return The tokenURI of the extension by the provided claimer
     function extensionOfULByClaimer(
         string calldata _universalLocation,
         address _claimer
     ) external view returns (string memory);
 
-    /// @notice Checks if a token's universal location has an extension by a claimer
-    /// @param _universalLocation Universal location of the token
-    /// @param _claimer Address of the claimer
-    /// @return True if there is an extension, false otherwise
+    /// @notice Checks if a Universal Location has an extension by a claimer
+    /// @param _universalLocation The Universal Location
+    /// @param _claimer The address of the claimer
+    /// @return True if the Universal Location has an extension by the provided claimer, false otherwise
     function hasExtensionByClaimer(
         string calldata _universalLocation,
         address _claimer

--- a/ownership-chain/precompile/asset-metadata-extender/contracts/AssetMetadataExtender.sol
+++ b/ownership-chain/precompile/asset-metadata-extender/contracts/AssetMetadataExtender.sol
@@ -58,4 +58,22 @@ interface AssetMetadataExtender {
         string calldata uloc,
         uint256 index
     ) external view returns (string memory);
+
+    /// @notice Retrieves the extension of a token's universal location by a claimer
+    /// @param _universalLocation Universal location of the token
+    /// @param _claimer Address of the claimer
+    /// @return Extension of the token's universal location
+    function extensionOfULByClaimer(
+        string calldata _universalLocation,
+        address _claimer
+    ) external view returns (string memory);
+
+    /// @notice Checks if a token's universal location has an extension by a claimer
+    /// @param _universalLocation Universal location of the token
+    /// @param _claimer Address of the claimer
+    /// @return True if there is an extension, false otherwise
+    function hasExtensionByClaimer(
+        string calldata _universalLocation,
+        address _claimer
+    ) external view returns (bool);
 }

--- a/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
@@ -281,14 +281,14 @@ where
 			claimer.into(),
 		);
 
-		Ok(succeed(bool_to_32_bytes(has_extension)))	
+		Ok(succeed(bool_to_32_bytes(has_extension)))
 	}
 }
 
 fn bool_to_32_bytes(value: bool) -> [u8; 32] {
-    let mut output = [0u8; 32]; // Create a 32-byte array initialized with zeros
-    output[31] = value as u8;   // Set the last byte to the boolean value
-    output
+	let mut output = [0u8; 32]; // Create a 32-byte array initialized with zeros
+	output[31] = value as u8; // Set the last byte to the boolean value
+	output
 }
 
 #[cfg(test)]

--- a/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
@@ -36,7 +36,7 @@ pub enum Action {
 	/// Get token uri of a given universal location using indexation
 	Extension = "extensionOfULByIndex(string,uint32)", // TODO rename `extension` for `tokenURI`?
 	/// Update token uri of a given universal location using indexation
-  Update = "updateExtendedTokenURI(string,string)",
+	Update = "updateExtendedTokenURI(string,string)",
 	/// Get claimer of a given universal location using claimer
 	ExtensionOfULByClaimer = "extensionOfULByClaimer(string,address)",
 	/// Check if a given universal location has an extension

--- a/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
@@ -37,7 +37,7 @@ pub enum Action {
 	Extension = "extensionOfULByIndex(string,uint32)", // TODO rename `extension` for `tokenURI`?
 	/// Update token uri of a given universal location using indexation
 	Update = "updateExtendedTokenURI(string,string)",
-	/// Get claimer of a given universal location using claimer
+	/// Get extension of a given universal location using claimer
 	ExtensionOfULByClaimer = "extensionOfULByClaimer(string,address)",
 	/// Check if a given universal location has an extension
 	HasExtension = "hasExtensionByClaimer(string,address)",

--- a/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
@@ -281,14 +281,8 @@ where
 			claimer.into(),
 		);
 
-		Ok(succeed(bool_to_32_bytes(has_extension)))
+		Ok(succeed(EvmDataWriter::new().write(has_extension).build()))
 	}
-}
-
-fn bool_to_32_bytes(value: bool) -> [u8; 32] {
-	let mut output = [0u8; 32]; // Create a 32-byte array initialized with zeros
-	output[31] = value as u8; // Set the last byte to the boolean value
-	output
 }
 
 #[cfg(test)]

--- a/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
@@ -264,7 +264,7 @@ where
 		)
 		.ok_or_else(|| revert("invalid ul"))?;
 
-		Ok(succeed(token_uri.into_inner()))
+		Ok(succeed(EvmDataWriter::new().write(Bytes(token_uri.into_inner())).build()))
 	}
 
 	fn has_extension_by_claimer(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {

--- a/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
@@ -259,8 +259,8 @@ where
 		let claimer = input.read::<Address>().map_err(|_| revert("invalid claimer"))?.0;
 
 		let token_uri = AssetMetadataExtender::<Runtime>::extension_by_location_and_claimer(
-			claimer.into(),
 			universal_location.clone(),
+			claimer.into(),
 		)
 		.ok_or_else(|| revert("invalid ul"))?;
 

--- a/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/lib.rs
@@ -281,8 +281,14 @@ where
 			claimer.into(),
 		);
 
-		Ok(success(has_extension))	
+		Ok(succeed(bool_to_32_bytes(has_extension)))	
 	}
+}
+
+fn bool_to_32_bytes(value: bool) -> [u8; 32] {
+    let mut output = [0u8; 32]; // Create a 32-byte array initialized with zeros
+    output[31] = value as u8;   // Set the last byte to the boolean value
+    output
 }
 
 #[cfg(test)]

--- a/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
@@ -530,7 +530,7 @@ fn extension_by_location_and_claimer_works() {
 }
 
 #[test]
-fn extension_by_location_and_claimer_of_inexistent_claim_reverts() {
+fn extension_by_location_and_claimer_of_unexistent_claim_reverts() {
 	new_test_ext().execute_with(|| {
 		let universal_location = Bytes("some_universal_location".as_bytes().to_vec());
 		let claimer = H160::from_str(TEST_CLAIMER).unwrap();
@@ -574,7 +574,7 @@ fn has_extension_by_claim_of_existent_claim_returns_true() {
 }
 
 #[test]
-fn has_extension_by_claimer_of_inexistent_claim_returns_false() {
+fn has_extension_by_claimer_of_unexistent_claim_returns_false() {
 	new_test_ext().execute_with(|| {
 		let universal_location = Bytes("some_universal_location".as_bytes().to_vec());
 		let claimer = H160::from_str(TEST_CLAIMER).unwrap();

--- a/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
@@ -528,7 +528,7 @@ fn extension_by_location_and_claimer_works() {
 }
 
 #[test]
-fn extension_by_location_and_claimer_of_unexistent_claim_should_revert() {
+fn extension_by_location_and_claimer_of_inexistent_claim_reverts() {
 	new_test_ext().execute_with(|| {
 		let universal_location = Bytes("some_universal_location".as_bytes().to_vec());
 		let claimer = H160::from_str(TEST_CLAIMER).unwrap();

--- a/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
@@ -572,7 +572,7 @@ fn has_extension_by_claim_of_existent_claim_should_return_true() {
 }
 
 #[test]
-fn has_extension_by_claimer_of_unexistent_claim_should_return_false() {
+fn has_extension_by_claimer_of_inexistent_claim_returns_false() {
 	new_test_ext().execute_with(|| {
 		let universal_location = Bytes("some_universal_location".as_bytes().to_vec());
 		let claimer = H160::from_str(TEST_CLAIMER).unwrap();

--- a/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
@@ -513,11 +513,7 @@ fn extension_by_location_and_claimer_works() {
 			.build();
 
 		precompiles()
-			.prepare_test(
-				claimer.clone(),
-				H160(PRECOMPILE_ADDRESS),
-				input.clone(),
-			)
+			.prepare_test(claimer.clone(), H160(PRECOMPILE_ADDRESS), input.clone())
 			.execute_returns_raw(sp_std::vec![]);
 
 		let input = EvmDataWriter::new_with_selector(Action::ExtensionOfULByClaimer)
@@ -561,11 +557,7 @@ fn has_extension_by_claim_of_existent_claim_should_return_true() {
 			.build();
 
 		precompiles()
-			.prepare_test(
-				claimer.clone(),
-				H160(PRECOMPILE_ADDRESS),
-				input.clone(),
-			)
+			.prepare_test(claimer.clone(), H160(PRECOMPILE_ADDRESS), input.clone())
 			.execute_returns_raw(sp_std::vec![]);
 
 		let input = EvmDataWriter::new_with_selector(Action::HasExtension)
@@ -580,7 +572,7 @@ fn has_extension_by_claim_of_existent_claim_should_return_true() {
 }
 
 #[test]
-fn has_extension_by_claimer_of_unexistent_claim_should_return_false(){
+fn has_extension_by_claimer_of_unexistent_claim_should_return_false() {
 	new_test_ext().execute_with(|| {
 		let universal_location = Bytes("some_universal_location".as_bytes().to_vec());
 		let claimer = H160::from_str(TEST_CLAIMER).unwrap();

--- a/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
@@ -525,7 +525,7 @@ fn extension_by_location_and_claimer_works() {
 
 		precompiles()
 			.prepare_test(claimer, H160(PRECOMPILE_ADDRESS), input)
-			.execute_returns_raw(claim.into());
+			.execute_returns(BoundedBytes::<MaxTokenUriLength>::from(vec![1u8; 10]));
 	});
 }
 
@@ -547,7 +547,7 @@ fn extension_by_location_and_claimer_of_inexistent_claim_reverts() {
 }
 
 #[test]
-fn has_extension_by_claim_of_existent_claim_should_return_true() {
+fn has_extension_by_claim_of_existent_claim_returns_true() {
 	new_test_ext().execute_with(|| {
 		let universal_location = Bytes("some_universal_location".as_bytes().to_vec());
 		let claimer = H160::from_str(TEST_CLAIMER).unwrap();

--- a/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
+++ b/ownership-chain/precompile/asset-metadata-extender/src/tests.rs
@@ -547,3 +547,51 @@ fn extension_by_location_and_claimer_of_unexistent_claim_should_revert() {
 			.execute_reverts(|r| r == b"invalid ul");
 	});
 }
+
+#[test]
+fn has_extension_by_claim_of_existent_claim_should_return_true() {
+	new_test_ext().execute_with(|| {
+		let universal_location = Bytes("some_universal_location".as_bytes().to_vec());
+		let claimer = H160::from_str(TEST_CLAIMER).unwrap();
+		let claim = Bytes(vec![1u8; 10]);
+
+		let input = EvmDataWriter::new_with_selector(Action::Extend)
+			.write(universal_location.clone())
+			.write(claim.clone())
+			.build();
+
+		precompiles()
+			.prepare_test(
+				claimer.clone(),
+				H160(PRECOMPILE_ADDRESS),
+				input.clone(),
+			)
+			.execute_returns_raw(sp_std::vec![]);
+
+		let input = EvmDataWriter::new_with_selector(Action::HasExtension)
+			.write(universal_location.clone())
+			.write(Address::from(claimer.clone()))
+			.build();
+
+		precompiles()
+			.prepare_test(claimer, H160(PRECOMPILE_ADDRESS), input)
+			.execute_returns(true);
+	});
+}
+
+#[test]
+fn has_extension_by_claimer_of_unexistent_claim_should_return_false(){
+	new_test_ext().execute_with(|| {
+		let universal_location = Bytes("some_universal_location".as_bytes().to_vec());
+		let claimer = H160::from_str(TEST_CLAIMER).unwrap();
+
+		let input = EvmDataWriter::new_with_selector(Action::HasExtension)
+			.write(universal_location.clone())
+			.write(Address::from(claimer.clone()))
+			.build();
+
+		precompiles()
+			.prepare_test(claimer, H160(PRECOMPILE_ADDRESS), input)
+			.execute_returns(false);
+	});
+}


### PR DESCRIPTION
## **Type**
Enhancement, Tests


___

## **Description**
- Added two new functions to the `AssetMetadataExtender` struct and trait in the `asset-metadata-extender` pallet: `extension_by_location_and_claimer` and `has_extension`. These functions allow retrieving the token URI extension based on the claimer and universal location, and checking if a token URI extension exists for the given universal location and claimer, respectively.
- Added corresponding methods to handle the new `ExtensionOfULByClaimer` and `HasExtension` actions in the `AssetMetadataExtenderPrecompile` struct in the `asset-metadata-extender` precompile.
- Added new tests in both the `asset-metadata-extender` pallet and precompile to verify the functionality of the newly added functions and actions.
- Added the corresponding methods to the `AssetMetadataExtender` interface in the `AssetMetadataExtender.sol` contract.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/src/lib.rs<br><br>

**Two new functions were added to the `AssetMetadataExtender` <br>struct: `extension_by_location_and_claimer` and <br>`has_extension`. The former retrieves the token URI <br>extension based on the claimer and universal location, while <br>the latter checks if a token URI extension exists for the <br>given universal location and claimer.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/284/files#diff-0b98d958eb954215a590ddfb8dfd04c42342b3e8b0a5edf43ef26a53da417602"> +11/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>traits.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/src/traits.rs<br><br>

**Two new methods were added to the `AssetMetadataExtender` <br>trait: `extension_by_location_and_claimer` and <br>`has_extension`. These methods correspond to the functions <br>added to the `AssetMetadataExtender` struct in `lib.rs`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/284/files#diff-fa633908831a73db8a43b25720fe973224d8b38c5b4840f88c65e3586deffb08"> +9/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/asset-metadata-extender/src/lib.rs<br><br>

**Two new actions were added to the `Action` enum: <br>`ExtensionOfULByClaimer` and `HasExtension`. Corresponding <br>methods were also added to the <br>`AssetMetadataExtenderPrecompile` struct to handle these <br>actions. The `extension_by_location_and_claimer` method <br>retrieves the token URI extension based on the claimer and <br>universal location, and the `has_extension_by_claimer` <br>method checks if a token URI extension exists for the given <br>universal location and claimer.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/284/files#diff-03d2e3ae6122d354ae5cc5bf64d2a128dea59a10fe266b4488132fc42db27647"> +48/-3</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AssetMetadataExtender.sol&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/asset-metadata-extender/contracts/AssetMetadataExtender.sol<br><br>

**Two new methods were added to the `AssetMetadataExtender` <br>interface: `extensionOfULByClaimer` and <br>`hasExtensionByClaimer`. These methods correspond to the <br>actions added to the `Action` enum in `lib.rs`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/284/files#diff-2fb3689970ce4af7a788122dbfe6a6fb7c4b6b7eec00a89b4711a5ad3a8eb92e"> +18/-0</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/pallets/asset-metadata-extender/src/tests.rs<br><br>

**Four new tests were added to verify the functionality of the <br>newly added functions: <br>`get_unexistent_extension_by_location_and_claimer_fails`, <br>`get_extension_by_location_and_claimer_works`, <br>`has_extension_should_return_true_if_it_exists`, and <br>`has_extension_should_return_false_if_it_does_not_exist`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/284/files#diff-d7cf71ea174fb578d9d86db7d2fe30f940d183fb80a7db5db8fe5c15da4d109d"> +57/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tests.rs&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        ownership-chain/precompile/asset-metadata-extender/src/tests.rs<br><br>

**Four new tests were added to verify the functionality of the <br>newly added precompile actions: <br>`extension_by_location_and_claimer_works`, <br>`extension_by_location_and_claimer_of_unexistent_claim_should_revert`, <br>`has_extension_by_claim_of_existent_claim_should_return_true`, <br>and <br>`has_extension_by_claimer_of_unexistent_claim_should_return_false`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/284/files#diff-2b01a0334f99725037a379b5917963cb9c6245563ec1005b6eba044c4d0f1ee5"> +96/-0</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
