### PR TITLE
Add community incentive account as rewards source

### DIFF
--- a/ownership-chain/pallets/parachain-staking/Cargo.toml
+++ b/ownership-chain/pallets/parachain-staking/Cargo.toml
@@ -29,7 +29,7 @@ sp-runtime = { workspace = true }
 [features]
 default = [ "std" ]
 std = [
-	"frame-benchmarking",
+	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
 	"parity-scale-codec/std",

--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -510,6 +510,11 @@ pub mod pallet {
 	pub(crate) type CandidateInfo<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, CandidateMetadata<BalanceOf<T>>, OptionQuery>;
 
+	/// Stores whether inflation is activated
+	#[pallet::storage]
+	#[pallet::getter(fn inflation_activated)]
+	pub type InflationActivated<T: Config> = StorageValue<_, (), OptionQuery>;
+
 	pub struct AddGet<T, R> {
 		_phantom: PhantomData<(T, R)>,
 	}
@@ -1392,6 +1397,26 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			T::MonetaryGovernanceOrigin::ensure_origin(origin.clone())?;
 			Self::join_candidates_inner(account, bond, candidate_count)
+		}
+
+		/// Activate inflation so rewards are created from inflation
+		/// Only `sudo` can call this function
+		#[pallet::call_index(32)]
+		#[pallet::weight(Weight::from_parts(3_000_000u64, 4_000u64))] // TODO
+		pub fn activate_inflation(origin: OriginFor<T>) -> DispatchResult {
+			ensure_root(origin)?;
+			<InflationActivated<T>>::put(());
+			Ok(())
+		}
+
+		/// Deactivate inflation so rewards are created from inflation
+		/// Only `sudo` can call this function
+		#[pallet::call_index(33)]
+		#[pallet::weight(Weight::from_parts(3_000_000u64, 4_000u64))] // TODO
+		pub fn deactivate_inflation(origin: OriginFor<T>) -> DispatchResult {
+			ensure_root(origin)?;
+			<InflationActivated<T>>::kill();
+			Ok(())
 		}
 	}
 

--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -1419,8 +1419,11 @@ pub mod pallet {
 
 		/// Set community incentives account
 		/// Only `sudo` can call this function
-		#[pallet::call_index(34)]
-		#[pallet::weight(Weight::from_parts(3_000_000u64, 4_000u64))] // TODO
+		#[pallet::call_index(33)]
+		#[pallet::weight(
+			Weight::from_parts(3_000_000u64, 4_000u64)
+				.saturating_add(T::DbWeight::get().writes(1u64))
+		)]
 		pub fn set_community_incentives_account(
 			origin: OriginFor<T>,
 			account: T::AccountId,

--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -1851,10 +1851,7 @@ pub mod pallet {
 			}
 
 			let collator_fee = payout_info.collator_commission;
-			let collator_issuance = collator_fee * payout_info.round_issuance; // 20%
-																   // println!("collator_issuance: {:?}", collator_issuance);
-																   // println!("collator_fee: {:?}", collator_fee);
-																   // println!("payout_info.round_issuance: {:?}", payout_info.round_issuance);
+			let collator_issuance = collator_fee * payout_info.round_issuance;
 			if let Some((collator, state)) =
 				<AtStake<T>>::iter_prefix(paid_for_round).drain().next()
 			{
@@ -1872,7 +1869,7 @@ pub mod pallet {
 				// 'extra_weight' tracks weight returned from fns that we delegate to which can't be
 				// known ahead of time.
 				let mut extra_weight = Weight::zero();
-				let pct_due = Perbill::from_rational(pts, total_points); // 100 / 100
+				let pct_due = Perbill::from_rational(pts, total_points);
 				let total_paid = pct_due * payout_info.total_staking_reward;
 				let mut amt_due = total_paid;
 

--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -1808,7 +1808,10 @@ pub mod pallet {
 			}
 
 			let collator_fee = payout_info.collator_commission;
-			let collator_issuance = collator_fee * payout_info.round_issuance;
+			let collator_issuance = collator_fee * payout_info.round_issuance; // 20%
+																   // println!("collator_issuance: {:?}", collator_issuance);
+																   // println!("collator_fee: {:?}", collator_fee);
+																   // println!("payout_info.round_issuance: {:?}", payout_info.round_issuance);
 			if let Some((collator, state)) =
 				<AtStake<T>>::iter_prefix(paid_for_round).drain().next()
 			{
@@ -1826,7 +1829,7 @@ pub mod pallet {
 				// 'extra_weight' tracks weight returned from fns that we delegate to which can't be
 				// known ahead of time.
 				let mut extra_weight = Weight::zero();
-				let pct_due = Perbill::from_rational(pts, total_points);
+				let pct_due = Perbill::from_rational(pts, total_points); // 100 / 100
 				let total_paid = pct_due * payout_info.total_staking_reward;
 				let mut amt_due = total_paid;
 

--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -1756,7 +1756,7 @@ pub mod pallet {
 			// reserve portion of issuance for parachain bond account
 			let bond_config = <ParachainBondInfo<T>>::get();
 			let parachain_bond_reserve = bond_config.percent * total_issuance;
-			if let Ok(Reward::Imbalance(imb)) =
+			if let Ok(RewardSource::Inflation(imb)) =
 				Self::send_rewards(&bond_config.account, parachain_bond_reserve)
 			{
 				// update round issuance iff transfer succeeds
@@ -2127,7 +2127,7 @@ pub mod pallet {
 
 		/// Mint a specified reward amount to the beneficiary account. Emits the [Rewarded] event.
 		pub fn mint(amt: BalanceOf<T>, to: T::AccountId) {
-			if let Ok(Reward::Imbalance(amount_transferred)) = Self::send_rewards(&to, amt) {
+			if let Ok(RewardSource::Inflation(amount_transferred)) = Self::send_rewards(&to, amt) {
 				Self::deposit_event(Event::Rewarded {
 					account: to.clone(),
 					rewards: amount_transferred.peek(),
@@ -2141,7 +2141,8 @@ pub mod pallet {
 			collator_id: T::AccountId,
 			amt: BalanceOf<T>,
 		) -> Weight {
-			if let Ok(Reward::Imbalance(amount_transferred)) = Self::send_rewards(&collator_id, amt)
+			if let Ok(RewardSource::Inflation(amount_transferred)) =
+				Self::send_rewards(&collator_id, amt)
 			{
 				Self::deposit_event(Event::Rewarded {
 					account: collator_id.clone(),
@@ -2161,7 +2162,7 @@ pub mod pallet {
 			candidate: T::AccountId,
 			delegator: T::AccountId,
 		) {
-			if let Ok(Reward::Imbalance(amount_transferred)) =
+			if let Ok(RewardSource::Inflation(amount_transferred)) =
 				Self::send_rewards(&delegator, amt.clone())
 			{
 				Self::deposit_event(Event::Rewarded {
@@ -2199,14 +2200,19 @@ pub mod pallet {
 		pub fn send_rewards(
 			account: &T::AccountId,
 			amount: BalanceOf<T>,
-		) -> Result<Reward<T>, DispatchError> {
+		) -> Result<RewardSource<T>, DispatchError> {
 			T::Currency::deposit_into_existing(&account, amount)
-				.map(|imbalance| Reward::Imbalance(imbalance))
+				.map(|imbalance| RewardSource::Inflation(imbalance))
 				.map_err(|e| e.into())
 		}
 	}
-	pub enum Reward<T: Config> {
-		Imbalance(<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::PositiveImbalance),
+
+	/// The type of reward source
+	pub enum RewardSource<T: Config> {
+		/// The reward is from inflation, i.e. minting new tokens
+		Inflation(<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::PositiveImbalance),
+		/// The reward is from the community incentives account
+		IncentiveAccount(BalanceOf<T>)
 	}
 
 	/// Add reward points to block authors:

--- a/ownership-chain/pallets/parachain-staking/src/mock.rs
+++ b/ownership-chain/pallets/parachain-staking/src/mock.rs
@@ -160,6 +160,8 @@ pub(crate) struct ExtBuilder {
 	delegations: Vec<(AccountId, AccountId, Balance, Percent)>,
 	// inflation config
 	inflation: InflationInfo<Balance>,
+	// is inflation activated
+	inflation_activated: bool,
 }
 
 impl Default for ExtBuilder {
@@ -183,6 +185,8 @@ impl Default for ExtBuilder {
 					max: Perbill::from_percent(5),
 				},
 			},
+			// inflation is activated by default so we keep retrocompatibility with existing tests
+			inflation_activated: true,
 		}
 	}
 }
@@ -221,6 +225,11 @@ impl ExtBuilder {
 		self
 	}
 
+	pub(crate) fn with_inflation_activated(mut self, activated: bool) -> Self {
+		self.inflation_activated = activated;
+		self
+	}
+
 	pub(crate) fn build(self) -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::<Test>::default()
 			.build_storage()
@@ -243,6 +252,11 @@ impl ExtBuilder {
 
 		let mut ext = sp_io::TestExternalities::new(t);
 		ext.execute_with(|| System::set_block_number(1));
+		if self.inflation_activated {
+			ext.execute_with(|| {
+				pallet_parachain_staking::InflationActivated::<Test>::put(());
+			});
+		}
 		ext
 	}
 }

--- a/ownership-chain/pallets/parachain-staking/src/mock.rs
+++ b/ownership-chain/pallets/parachain-staking/src/mock.rs
@@ -161,7 +161,7 @@ pub(crate) struct ExtBuilder {
 	// inflation config
 	inflation: InflationInfo<Balance>,
 	// is inflation activated
-	inflation_activated: bool,
+	inflation_enabled: bool,
 }
 
 impl Default for ExtBuilder {
@@ -186,7 +186,7 @@ impl Default for ExtBuilder {
 				},
 			},
 			// inflation is activated by default so we keep retrocompatibility with existing tests
-			inflation_activated: true,
+			inflation_enabled: true,
 		}
 	}
 }
@@ -225,8 +225,8 @@ impl ExtBuilder {
 		self
 	}
 
-	pub(crate) fn with_inflation_activated(mut self, activated: bool) -> Self {
-		self.inflation_activated = activated;
+	pub(crate) fn with_inflation_enabled(mut self, enabled: bool) -> Self {
+		self.inflation_enabled = enabled;
 		self
 	}
 
@@ -252,11 +252,9 @@ impl ExtBuilder {
 
 		let mut ext = sp_io::TestExternalities::new(t);
 		ext.execute_with(|| System::set_block_number(1));
-		if self.inflation_activated {
-			ext.execute_with(|| {
-				pallet_parachain_staking::InflationActivated::<Test>::put(());
-			});
-		}
+		ext.execute_with(|| {
+			pallet_parachain_staking::InflationEnabled::<Test>::set(self.inflation_enabled);
+		});
 		ext
 	}
 }

--- a/ownership-chain/pallets/parachain-staking/src/tests.rs
+++ b/ownership-chain/pallets/parachain-staking/src/tests.rs
@@ -31,13 +31,10 @@ use crate::{
 		Balances, BlockNumber, ExtBuilder, ParachainStaking, RuntimeOrigin, Test,
 	},
 	AtStake, Bond, CollatorStatus, DelegationScheduledRequests, DelegatorAdded,
-	EnableMarkingOffline, Error, Event, Range, RewardSource, DELEGATOR_LOCK_ID,
+	EnableMarkingOffline, Error, Event, Range, DELEGATOR_LOCK_ID,
 };
 use frame_support::{
-	assert_err, assert_noop, assert_ok,
-	pallet_prelude::*,
-	traits::{Currency, Imbalance},
-	BoundedVec,
+	assert_err, assert_noop, assert_ok, pallet_prelude::*, traits::Currency, BoundedVec,
 };
 use sp_runtime::{traits::Zero, DispatchError, ModuleError, Perbill, Percent};
 
@@ -358,12 +355,10 @@ fn send_rewards_with_inflation_activated_works() {
 		assert!(ParachainStaking::inflation_enabled());
 		let total_issuance = Balances::total_issuance();
 		assert_eq!(Balances::total_balance(&collator), collator_balance);
-		match ParachainStaking::send_rewards(&collator, reward_amount).unwrap() {
-			RewardSource::Inflation(amount_rewarded) => {
-				assert_eq!(amount_rewarded.peek(), reward_amount);
-			},
-			_ => panic!("unexpected reward source"),
-		}
+		assert_eq!(
+			ParachainStaking::send_rewards(&collator, reward_amount).unwrap(),
+			reward_amount
+		);
 		assert_eq!(Balances::total_balance(&collator), reward_amount + collator_balance);
 		assert_eq!(Balances::total_issuance(), reward_amount + total_issuance);
 	});
@@ -389,12 +384,10 @@ fn send_rewards_without_inflation_activated_works() {
 			assert_eq!(Balances::total_balance(&ci_account), 100);
 			assert_eq!(Balances::total_balance(&collator), collator_balance);
 			let total_issuance = Balances::total_issuance();
-			match ParachainStaking::send_rewards(&collator, reward_amount).unwrap() {
-				RewardSource::IncentiveAccount(amount_rewarded) => {
-					assert_eq!(amount_rewarded, reward_amount);
-				},
-				_ => panic!("unexpected reward source"),
-			}
+			assert_eq!(
+				ParachainStaking::send_rewards(&collator, reward_amount).unwrap(),
+				reward_amount
+			);
 			assert_eq!(Balances::total_balance(&ci_account), 0);
 			assert_eq!(Balances::total_balance(&collator), reward_amount + collator_balance);
 			assert_eq!(Balances::total_issuance(), total_issuance);
@@ -457,13 +450,7 @@ fn send_rewards_when_community_incentives_account_is_not_set() {
 		let collator = 2;
 		assert!(ParachainStaking::inflation_enabled() == false);
 		assert!(ParachainStaking::community_incentives_account().is_none());
-
-		match ParachainStaking::send_rewards(&collator, 100).unwrap() {
-			RewardSource::IncentiveAccount(amount_rewarded) => {
-				assert_eq!(amount_rewarded, 0);
-			},
-			_ => panic!("unexpected reward source"),
-		}
+		assert_eq!(ParachainStaking::send_rewards(&collator, 100).unwrap(), 0);
 	});
 }
 
@@ -481,13 +468,7 @@ fn send_rewards_when_community_incentives_account_has_no_enough_funds() {
 			ParachainStaking::community_incentives_account().unwrap() ==
 				community_incentives_account
 		);
-
-		match ParachainStaking::send_rewards(&collator, 100).unwrap() {
-			RewardSource::IncentiveAccount(amount_rewarded) => {
-				assert_eq!(amount_rewarded, 0);
-			},
-			_ => panic!("unexpected reward source"),
-		}
+		assert_eq!(ParachainStaking::send_rewards(&collator, 100).unwrap(), 0);
 	});
 }
 

--- a/ownership-chain/pallets/parachain-staking/src/tests.rs
+++ b/ownership-chain/pallets/parachain-staking/src/tests.rs
@@ -368,8 +368,30 @@ fn send_rewards_without_inflation_activate_does_not_increase_total_issuance() {
 }
 
 #[test]
-fn only_sudo_can_activate_inflation() {
-	unimplemented!();
+fn only_sudo_can_change_activate_inflation() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert!(ParachainStaking::inflation_activated().is_none());
+		assert_noop!(
+			ParachainStaking::activate_inflation(RuntimeOrigin::signed(1)),
+			sp_runtime::DispatchError::BadOrigin
+		);
+		assert_ok!(ParachainStaking::activate_inflation(RuntimeOrigin::root()));
+		assert!(ParachainStaking::inflation_activated().is_some());
+	});
+}
+
+#[test]
+fn only_sudo_can_deactivate_inflation() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(ParachainStaking::activate_inflation(RuntimeOrigin::root()));
+		assert!(ParachainStaking::inflation_activated().is_some());
+		assert_noop!(
+			ParachainStaking::deactivate_inflation(RuntimeOrigin::signed(1)),
+			sp_runtime::DispatchError::BadOrigin
+		);
+		assert_ok!(ParachainStaking::deactivate_inflation(RuntimeOrigin::root()));
+		assert!(ParachainStaking::inflation_activated().is_none());
+	});
 }
 
 #[test]

--- a/ownership-chain/pallets/parachain-staking/src/tests.rs
+++ b/ownership-chain/pallets/parachain-staking/src/tests.rs
@@ -3698,7 +3698,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 		});
 }
 
-#[test] // TODO
+#[test]
 fn paid_collator_commission_matches_config() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 100), (2, 100), (3, 100), (4, 100), (5, 100), (6, 100)])
@@ -3891,7 +3891,7 @@ fn collator_selection_chooses_top_candidates() {
 		});
 }
 
-#[test] // TODO
+#[test]
 fn payout_distribution_to_solo_collators() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 1000), (2, 1000), (3, 1000), (4, 1000), (7, 33), (8, 33), (9, 33)])
@@ -4739,7 +4739,7 @@ fn delegation_events_convey_correct_position() {
 		});
 }
 
-#[test] // TODO
+#[test]
 fn no_rewards_paid_until_after_reward_payment_delay() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 20), (2, 20), (3, 20)])
@@ -6217,7 +6217,7 @@ fn test_rewards_do_not_auto_compound_on_payment_if_delegation_scheduled_revoke_e
 		});
 }
 
-#[test] // TODO
+#[test]
 fn test_rewards_auto_compound_on_payment_as_per_auto_compound_config() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 100), (2, 200), (3, 200), (4, 200), (5, 200)])

--- a/ownership-chain/pallets/parachain-staking/src/tests.rs
+++ b/ownership-chain/pallets/parachain-staking/src/tests.rs
@@ -3559,7 +3559,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 		});
 }
 
-#[test]
+#[test] // TODO
 fn paid_collator_commission_matches_config() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 100), (2, 100), (3, 100), (4, 100), (5, 100), (6, 100)])
@@ -3752,7 +3752,7 @@ fn collator_selection_chooses_top_candidates() {
 		});
 }
 
-#[test]
+#[test] // TODO
 fn payout_distribution_to_solo_collators() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 1000), (2, 1000), (3, 1000), (4, 1000), (7, 33), (8, 33), (9, 33)])
@@ -4600,7 +4600,7 @@ fn delegation_events_convey_correct_position() {
 		});
 }
 
-#[test]
+#[test] // TODO
 fn no_rewards_paid_until_after_reward_payment_delay() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 20), (2, 20), (3, 20)])
@@ -6078,7 +6078,7 @@ fn test_rewards_do_not_auto_compound_on_payment_if_delegation_scheduled_revoke_e
 		});
 }
 
-#[test]
+#[test] // TODO
 fn test_rewards_auto_compound_on_payment_as_per_auto_compound_config() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 100), (2, 200), (3, 200), (4, 200), (5, 200)])

--- a/ownership-chain/pallets/parachain-staking/src/tests.rs
+++ b/ownership-chain/pallets/parachain-staking/src/tests.rs
@@ -395,8 +395,26 @@ fn only_sudo_can_deactivate_inflation() {
 }
 
 #[test]
-fn only_sudo_can_setup_community_incentives_account() {
-	unimplemented!();
+fn only_sudo_can_set_community_incentives_account() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert!(ParachainStaking::community_incentives_account().is_none());
+		let community_incentives_account = 1;
+		assert_noop!(
+			ParachainStaking::set_community_incentives_account(
+				RuntimeOrigin::signed(1),
+				community_incentives_account
+			),
+			sp_runtime::DispatchError::BadOrigin
+		);
+		assert_ok!(ParachainStaking::set_community_incentives_account(
+			RuntimeOrigin::root(),
+			community_incentives_account
+		));
+		assert!(
+			ParachainStaking::community_incentives_account().unwrap() ==
+				community_incentives_account
+		);
+	});
 }
 
 #[test]

--- a/ownership-chain/pallets/parachain-staking/src/tests.rs
+++ b/ownership-chain/pallets/parachain-staking/src/tests.rs
@@ -344,6 +344,49 @@ fn invalid_monetary_origin_fails() {
 	});
 }
 
+#[test]
+fn send_rewards_with_inflation_activated_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		// let account = 1;
+		// let amount = 100;
+		// assert_ok!(ParachainStaking::send_rewards(&account, amount));
+		// total issuance increases
+		// ci account doesnt decrease
+	});
+}
+
+#[test]
+fn send_rewards_without_inflation_activated_works() {
+	unimplemented!();
+	// total issuance stays the same
+	// ci account decreases
+}
+
+#[test]
+fn send_rewards_without_inflation_activate_does_not_increase_total_issuance() {
+	unimplemented!();
+}
+
+#[test]
+fn only_sudo_can_activate_inflation() {
+	unimplemented!();
+}
+
+#[test]
+fn only_sudo_can_setup_community_incentives_account() {
+	unimplemented!();
+}
+
+#[test]
+fn send_rewards_when_community_incentives_account_is_not_setup() {
+	unimplemented!();
+}
+
+#[test]
+fn send_rewards_when_community_incentives_account_has_no_enough_funds() {
+	unimplemented!();
+}
+
 // SET STAKING EXPECTATIONS
 
 #[test]

--- a/ownership-chain/runtime/src/tests/mod.rs
+++ b/ownership-chain/runtime/src/tests/mod.rs
@@ -145,3 +145,8 @@ fn account_vests_correctly_over_time() {
 		assert_eq!(Balances::usable_balance(&bob), total_vested_amount);
 	});
 }
+
+#[test]
+fn staking_inflation_rewards_is_deactivated_by_default() {
+	new_test_ext().execute_with(|| assert!(ParachainStaking::inflation_activated().is_none()));
+}

--- a/ownership-chain/runtime/src/tests/mod.rs
+++ b/ownership-chain/runtime/src/tests/mod.rs
@@ -148,5 +148,5 @@ fn account_vests_correctly_over_time() {
 
 #[test]
 fn staking_inflation_rewards_is_deactivated_by_default() {
-	new_test_ext().execute_with(|| assert!(ParachainStaking::inflation_activated().is_none()));
+	new_test_ext().execute_with(|| assert!(ParachainStaking::inflation_enabled() == false));
 }


### PR DESCRIPTION
This pull request adds the necessary code to implement reward distribution from the community incentives account and inflation activation and deactivation functions:
- `pallet-staking` includes `send_rewards` new function that has the main logic to fullfill this task
- `pallet-staking` has new 2 extrinsics: `enable_inflation` and `set_community_incentives_account`
- `pallet-staking` has new 2 storage objects: `InflationActivated` and `CommunityIncentivesAccount`
- by default inflation is disabled
