### PR TITLE
Fixes for the issues found during QA

### DIFF
--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -1693,15 +1693,15 @@ pub mod pallet {
 
 				ensure!(!rewards.is_zero(), Error::<T>::RewardsNotFound);
 
-				let sent_rewards = Self::send_rewards(&target, rewards)?;
+				let rewards_sent = Self::send_rewards(&target, rewards)?;
 
-				if sent_rewards == rewards {
+				if rewards_sent == rewards {
 					*maybe_rewards = None;
 				} else {
-					*maybe_rewards = Some(rewards.saturating_sub(sent_rewards));
+					*maybe_rewards = Some(rewards.saturating_sub(rewards_sent));
 				}
 
-				Self::deposit_event(Event::Rewarded(target, sent_rewards));
+				Self::deposit_event(Event::Rewarded(target, rewards_sent));
 
 				Ok(())
 			})

--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -500,6 +500,12 @@ pub mod pallet {
 		/// \[round number, first block in the current round, old value, new
 		/// value\]
 		BlocksPerRoundSet(SessionIndex, BlockNumberFor<T>, BlockNumberFor<T>, BlockNumberFor<T>),
+		/// New treasury rewards account has been set.
+		/// \[new account\]
+		RewardsTreasuryAccountSet(T::AccountId),
+		/// Inflation feature is toggled.
+		/// \[enabled\]
+		InflationEnabled(bool),
 	}
 
 	#[pallet::hooks]
@@ -1804,6 +1810,7 @@ pub mod pallet {
 		pub fn toggle_inflation(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
 			<InflationEnabled<T>>::put(!InflationEnabled::<T>::get());
+			Self::deposit_event(Event::InflationEnabled(InflationEnabled::<T>::get()));
 			Ok(())
 		}
 
@@ -1817,7 +1824,8 @@ pub mod pallet {
 			account: T::AccountId,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			<RewardsTreasuryAccount<T>>::put(account);
+			<RewardsTreasuryAccount<T>>::put(account.clone());
+			Self::deposit_event(Event::RewardsTreasuryAccountSet(account));
 			Ok(())
 		}
 	}

--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -1809,8 +1809,9 @@ pub mod pallet {
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::toggle_inflation())]
 		pub fn toggle_inflation(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
-			<InflationEnabled<T>>::put(!InflationEnabled::<T>::get());
-			Self::deposit_event(Event::InflationEnabled(InflationEnabled::<T>::get()));
+			let inflation_enabled = InflationEnabled::<T>::get();
+			<InflationEnabled<T>>::put(!inflation_enabled);
+			Self::deposit_event(Event::InflationEnabled(!inflation_enabled));
 			Ok(())
 		}
 

--- a/ownership-chain/pallets/parachain-staking/src/mock.rs
+++ b/ownership-chain/pallets/parachain-staking/src/mock.rs
@@ -23,7 +23,7 @@ use super::*;
 use crate::{self as stake, types::CreditOf};
 use frame_support::{
 	assert_ok, construct_runtime, parameter_types,
-	traits::{fungible::Balanced, Currency, OnFinalize, OnInitialize, OnUnbalanced},
+	traits::{fungible::Balanced, OnFinalize, OnInitialize, OnUnbalanced},
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_authorship::EventHandler;

--- a/ownership-chain/pallets/parachain-staking/src/tests/rewards.rs
+++ b/ownership-chain/pallets/parachain-staking/src/tests/rewards.rs
@@ -20,17 +20,14 @@
 
 use crate::{
 	mock::{
-		almost_equal, roll_to, roll_to_claim_rewards, AccountId, AllPalletsWithSystem, Balance,
-		Balances, BlockNumber, ExtBuilder, RuntimeOrigin, StakePallet, System, Test, DECIMALS,
-		TREASURY_ACC, TREASURY_BALANCE,
+		almost_equal, roll_to, roll_to_claim_rewards, AccountId, Balance, Balances, BlockNumber,
+		ExtBuilder, RuntimeOrigin, StakePallet, System, Test, DECIMALS, TREASURY_ACC,
+		TREASURY_BALANCE,
 	},
 	types::{BalanceOf, StakeOf},
 	Config, Error, InflationInfo, RewardsTreasuryAccount,
 };
-use frame_support::{
-	assert_noop, assert_ok,
-	traits::{fungible::Inspect, OnFinalize, OnInitialize},
-};
+use frame_support::{assert_noop, assert_ok, traits::fungible::Inspect};
 use pallet_authorship::EventHandler;
 use sp_runtime::{traits::Zero, Perbill, Perquintill};
 
@@ -971,6 +968,71 @@ fn rewards_incrementing_and_claiming() {
 				StakePallet::increment_delegator_rewards(RuntimeOrigin::signed(1)),
 				Error::<Test>::DelegatorNotFound
 			);
+		});
+}
+
+#[test]
+fn claiming_rewards_while_no_treasury_does_not_reset_rewards() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, DECIMALS), (2, DECIMALS), (3, DECIMALS), (4, 100)])
+		.with_collators(vec![(1, DECIMALS), (4, 10)])
+		.with_delegators(vec![(2, 1, DECIMALS), (3, 1, DECIMALS)])
+		.build_and_execute_with_sanity_tests(|| {
+			// claiming should not be possible with zero counters
+			(1..=4).for_each(|id| {
+				assert_noop!(
+					StakePallet::claim_rewards(RuntimeOrigin::signed(id)),
+					Error::<Test>::RewardsNotFound,
+				);
+			});
+
+			// note once to set counter to 1
+			StakePallet::note_author(1);
+			assert_eq!(StakePallet::blocks_authored(1), 2);
+			assert!(StakePallet::blocks_rewarded(2).is_zero());
+
+			// claiming should not be possible before incrementing rewards
+			(1..=4).for_each(|id| {
+				assert_noop!(
+					StakePallet::claim_rewards(RuntimeOrigin::signed(id)),
+					Error::<Test>::RewardsNotFound
+				);
+			});
+
+			// increment rewards for 2 and match counter to collator
+			assert_ok!(StakePallet::increment_delegator_rewards(RuntimeOrigin::signed(2)));
+			assert_eq!(StakePallet::blocks_rewarded(2), 2);
+			let rewards_2 = StakePallet::rewards(2);
+
+			// should only update rewards for collator as well
+			assert_ok!(StakePallet::increment_collator_rewards(RuntimeOrigin::signed(1)));
+			assert_eq!(StakePallet::blocks_rewarded(1), StakePallet::blocks_authored(1));
+			assert!(!StakePallet::rewards(1).is_zero());
+			// rewards of 2 should not be changed
+			assert_eq!(StakePallet::rewards(2), rewards_2);
+			// 3 should still not have blocks rewarded bumped
+			assert!(StakePallet::blocks_rewarded(3).is_zero());
+
+			// one can claim rewards, but since there is no treasury, rewards are not set
+			// they are not reset either
+			assert_ok!(StakePallet::claim_rewards(RuntimeOrigin::signed(1)),);
+			assert!(!StakePallet::rewards(1).is_zero());
+
+			// set treasury account
+			assert_ok!(StakePallet::set_rewards_treasury_account(
+				RuntimeOrigin::root(),
+				TREASURY_ACC
+			));
+
+			// Give treasury some balance
+			<Balances as frame_support::traits::Currency<AccountId>>::make_free_balance_be(
+				&TREASURY_ACC,
+				1000 * DECIMALS,
+			);
+
+			// one can claim rewards, and rewards are reset
+			assert_ok!(StakePallet::claim_rewards(RuntimeOrigin::signed(1)),);
+			assert!(StakePallet::rewards(1).is_zero());
 		});
 }
 

--- a/ownership-chain/pallets/parachain-staking/src/tests/rewards.rs
+++ b/ownership-chain/pallets/parachain-staking/src/tests/rewards.rs
@@ -1099,6 +1099,7 @@ fn only_sudo_can_toggle_inflation() {
 		.with_inflation_enabled(false)
 		.build()
 		.execute_with(|| {
+			System::set_block_number(1);
 			assert!(StakePallet::inflation_enabled() == false);
 			assert_noop!(
 				StakePallet::toggle_inflation(RuntimeOrigin::signed(1)),
@@ -1106,6 +1107,10 @@ fn only_sudo_can_toggle_inflation() {
 			);
 			assert_ok!(StakePallet::toggle_inflation(RuntimeOrigin::root()));
 			assert!(StakePallet::inflation_enabled());
+			// assert event is emitted
+			System::assert_has_event(crate::mock::RuntimeEvent::StakePallet(
+				crate::Event::InflationEnabled(StakePallet::inflation_enabled()),
+			));
 		});
 }
 
@@ -1137,6 +1142,7 @@ fn only_sudo_can_set_rewards_treasury_account() {
 		.with_inflation_enabled(false)
 		.build()
 		.execute_with(|| {
+			System::set_block_number(1);
 			assert!(StakePallet::rewards_treasury_account() == Some(TREASURY_ACC));
 			let rewards_treasury_account = 1;
 			assert_noop!(
@@ -1151,6 +1157,11 @@ fn only_sudo_can_set_rewards_treasury_account() {
 				rewards_treasury_account
 			));
 			assert!(StakePallet::rewards_treasury_account().unwrap() == rewards_treasury_account);
+
+			// assert event is emitted
+			System::assert_has_event(crate::mock::RuntimeEvent::StakePallet(
+				crate::Event::RewardsTreasuryAccountSet(rewards_treasury_account),
+			));
 		});
 }
 


### PR DESCRIPTION
### Claim rewards reset
If the treasury rewards account is not set or it doesn't have enough funds, claiming rewards succeeds resetting the rewards to 0. But rewards are not actually transferred.

**Fix**:
use `try_mutate_exists()`. This will basically kill/take the storage value if it mutates to `None`. And in our case, it mutates to `None` if the full amount of rewards are transferred. 

NOTE: this means that if the treasury account is not set and you try to claim rewards, it will not fail but it won't reset the rewards either. I wanted to preserve the original behaviour of the pallet, so went for this approach

### Events missing

For our extrinsics `set_rewards_treasury_account` and `toggle_inflation`, we don't emit any events