### PR TITLE
Fix Reward Distribution in Parachain Staking Pallet

### DIFF
--- a/ownership-chain/pallets/parachain-staking/src/lib.rs
+++ b/ownership-chain/pallets/parachain-staking/src/lib.rs
@@ -88,7 +88,7 @@ pub mod pallet {
 		fail,
 		pallet_prelude::*,
 		traits::{
-			tokens::WithdrawReasons, Currency, Get, LockIdentifier, LockableCurrency,
+			tokens::WithdrawReasons, Currency, Get, Imbalance, LockIdentifier, LockableCurrency,
 			ReservableCurrency,
 		},
 	};
@@ -2125,10 +2125,10 @@ pub mod pallet {
 			collator_id: T::AccountId,
 			amt: BalanceOf<T>,
 		) -> Weight {
-			if let Ok(amount_transferred) = T::PayoutReward::payout(&collator_id, amt) {
+			if let Ok(amount_transferred) = T::Currency::deposit_into_existing(&collator_id, amt) {
 				Self::deposit_event(Event::Rewarded {
 					account: collator_id.clone(),
-					rewards: amount_transferred,
+					rewards: amount_transferred.peek(),
 				});
 			}
 			T::WeightInfo::mint_collator_reward()


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixed the reward distribution mechanism in the parachain staking pallet.
- Replaced the custom `payout` method with `Currency::deposit_into_existing` for depositing rewards.
- Ensured the `amount_transferred` is logged without being consumed by using `peek`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Update Reward Distribution Mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ownership-chain/pallets/parachain-staking/src/lib.rs
<li>Added <code>Imbalance</code> trait to the <code>traits</code> imports.<br> <li> Changed the reward payout mechanism to use <code>deposit_into_existing</code> <br>instead of a custom <code>payout</code> method.<br> <li> Updated the event logging to use <code>peek</code> on the <code>amount_transferred</code> to get <br>the value without consuming it.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/429/files#diff-a593863fa05ecc16d6aa0da861ad5b010e9e331be1263c334986a74ce033167f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

