### PR TITLE
Refactor Inflation Setup and Add Test for Constant Rewards

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -710,17 +710,6 @@ pub mod pallet {
 
 			assert!(self.blocks_per_round > 0, "Blocks per round must be > 0");
 
-			// Set inflation configuration
-			let mut inflation_config = self.inflation_config.clone();
-			// if all the round values are 0, derive them from the annual values
-			if inflation_config.round.min.is_zero() &&
-				inflation_config.round.ideal.is_zero() &&
-				inflation_config.round.max.is_zero()
-			{
-				inflation_config.set_round_from_annual::<T>(inflation_config.annual);
-			}
-			<InflationConfig<T>>::put(inflation_config);
-
 			let mut candidate_count = 0u32;
 			// Initialize the candidates
 			for &(ref candidate, balance) in &self.candidates {
@@ -810,6 +799,18 @@ pub mod pallet {
 			// Start Round 1 at Block 0
 			let round: RoundInfo<u64> = RoundInfo::new(1u32, 0u64, self.blocks_per_round);
 			<Round<T>>::put(round);
+
+			// Set inflation configuration
+			let mut inflation_config = self.inflation_config.clone();
+			// if all the round values are 0, derive them from the annual values
+			if inflation_config.round.min.is_zero() &&
+				inflation_config.round.ideal.is_zero() &&
+				inflation_config.round.max.is_zero()
+			{
+				inflation_config.set_round_from_annual::<T>(inflation_config.annual);
+			}
+			<InflationConfig<T>>::put(inflation_config);
+
 			// Snapshot total stake
 			<Staked<T>>::insert(1u32, <Total<T>>::get());
 			<Pallet<T>>::deposit_event(Event::NewRound {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -126,7 +126,6 @@ parameter_types! {
 	pub const MinCandidateStk: u128 = 10;
 	pub const MinDelegation: u128 = 3;
 	pub const MaxCandidates: u32 = 200;
-pub const SlotsPerYear:u32 = 31_557_600 / 6;
 }
 
 pub struct StakingRoundSlotProvider;
@@ -163,7 +162,7 @@ impl Config for Test {
 	type SlotProvider = StakingRoundSlotProvider;
 	type WeightInfo = ();
 	type MaxCandidates = MaxCandidates;
-	type SlotsPerYear = SlotsPerYear;
+	type SlotsPerYear = frame_support::traits::ConstU32<{ 31_557_600 / 6 }>;;
 }
 
 pub(crate) struct ExtBuilder {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -162,7 +162,7 @@ impl Config for Test {
 	type SlotProvider = StakingRoundSlotProvider;
 	type WeightInfo = ();
 	type MaxCandidates = MaxCandidates;
-	type SlotsPerYear = frame_support::traits::ConstU32<{ 31_557_600 / 6 }>;;
+	type SlotsPerYear = frame_support::traits::ConstU32<{ 31_557_600 / 6 }>;
 }
 
 pub(crate) struct ExtBuilder {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -126,6 +126,7 @@ parameter_types! {
 	pub const MinCandidateStk: u128 = 10;
 	pub const MinDelegation: u128 = 3;
 	pub const MaxCandidates: u32 = 200;
+pub const SlotsPerYear:u32 = 31_557_600 / 6;
 }
 
 pub struct StakingRoundSlotProvider;
@@ -162,7 +163,7 @@ impl Config for Test {
 	type SlotProvider = StakingRoundSlotProvider;
 	type WeightInfo = ();
 	type MaxCandidates = MaxCandidates;
-	type SlotsPerYear = frame_support::traits::ConstU32<{ 31_557_600 / 6 }>;
+	type SlotsPerYear = SlotsPerYear;
 }
 
 pub(crate) struct ExtBuilder {

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6759,7 +6759,7 @@ fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 				},
 			);
 			// pay total issuance to 1 at 2nd block
-			roll_blocks(1);
+			roll_blocks(3);
 			assert_events_eq!(Event::Rewarded { account: 1, rewards: 5205 });
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6724,7 +6724,15 @@ fn test_removed_calls() {
 fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 	let collator = 1;
 	ExtBuilder::default()
-		.with_balances(vec![(collator, 1000), (2, 1000), (3, 1000), (4, 1000), (7, 33), (8, 33), (9, 33)])
+		.with_balances(vec![
+			(collator, 1000),
+			(2, 1000),
+			(3, 1000),
+			(4, 1000),
+			(7, 33),
+			(8, 33),
+			(9, 33),
+		])
 		.with_candidates(vec![(collator, 100), (2, 90), (3, 80), (4, 70)])
 		.with_rewards_account(999, 100000)
 		.build()
@@ -6732,7 +6740,11 @@ fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 			roll_to_round_begin(2);
 			// should choose top TotalCandidatesSelected (5), in order
 			assert_events_eq!(
-				Event::CollatorChosen { round: 2, collator_account: collator, total_exposed_amount: 100 },
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: collator,
+					total_exposed_amount: 100
+				},
 				Event::CollatorChosen { round: 2, collator_account: 2, total_exposed_amount: 90 },
 				Event::CollatorChosen { round: 2, collator_account: 3, total_exposed_amount: 80 },
 				Event::CollatorChosen { round: 2, collator_account: 4, total_exposed_amount: 70 },
@@ -6746,20 +6758,29 @@ fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 			// ~ set block author as 1 for all blocks this round
 			set_author(2, collator, 100);
 			roll_to_round_begin(4);
-			assert_events_eq!(
-				Event::CollatorChosen { round: 4, collator_account: collator, total_exposed_amount: 100 },
-				Event::CollatorChosen { round: 4, collator_account: 2, total_exposed_amount: 90 },
-				Event::CollatorChosen { round: 4, collator_account: 3, total_exposed_amount: 80 },
-				Event::CollatorChosen { round: 4, collator_account: 4, total_exposed_amount: 70 },
-				Event::NewRound {
-					starting_block: 15,
-					round: 4,
-					selected_collators_number: 4,
-					total_balance: 340,
-				},
-			);
-			// pay total issuance to 1 at 2nd block
-			roll_blocks(3);
+			// assert_events_eq!(
+			// 	Event::CollatorChosen {
+			// 		round: 4,
+			// 		collator_account: collator,
+			// 		total_exposed_amount: 100
+			// 	},
+			// 	Event::CollatorChosen { round: 4, collator_account: 2, total_exposed_amount: 90 },
+			// 	Event::CollatorChosen { round: 4, collator_account: 3, total_exposed_amount: 80 },
+			// 	Event::CollatorChosen { round: 4, collator_account: 4, total_exposed_amount: 70 },
+			// 	Event::NewRound {
+			// 		starting_block: 15,
+			// 		round: 4,
+			// 		selected_collators_number: 4,
+			// 		total_balance: 340,
+			// 	},
+			// );
+			roll_blocks(1);
+			assert_no_events!();
+			roll_blocks(1);
+			assert_no_events!();
+			roll_blocks(1);
 			assert_events_eq!(Event::Rewarded { account: 1, rewards: 5205 });
+			roll_blocks(1);
+			assert_no_events!();
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6722,65 +6722,17 @@ fn test_removed_calls() {
 
 #[test]
 fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
-	let collator = 1;
+	let governance = 1;
+	let collator = 2;
 	ExtBuilder::default()
-		.with_balances(vec![
-			(collator, 1000),
-			(2, 1000),
-			(3, 1000),
-			(4, 1000),
-			(7, 33),
-			(8, 33),
-			(9, 33),
-		])
-		.with_candidates(vec![(collator, 100), (2, 90), (3, 80), (4, 70)])
-		.with_rewards_account(999, 100000)
+		.with_balances(vec![(governance, 840000000), (collator, 10000000)])
+		.with_candidates(vec![(collator, 100)])
+		.with_rewards_account(999, 150000000)
 		.build()
 		.execute_with(|| {
-			roll_to_round_begin(2);
-			// should choose top TotalCandidatesSelected (5), in order
-			assert_events_eq!(
-				Event::CollatorChosen {
-					round: 2,
-					collator_account: collator,
-					total_exposed_amount: 100
-				},
-				Event::CollatorChosen { round: 2, collator_account: 2, total_exposed_amount: 90 },
-				Event::CollatorChosen { round: 2, collator_account: 3, total_exposed_amount: 80 },
-				Event::CollatorChosen { round: 2, collator_account: 4, total_exposed_amount: 70 },
-				Event::NewRound {
-					starting_block: 5,
-					round: 2,
-					selected_collators_number: 4,
-					total_balance: 340,
-				},
-			);
-			// ~ set block author as 1 for all blocks this round
 			set_author(2, collator, 100);
 			roll_to_round_begin(4);
-			// assert_events_eq!(
-			// 	Event::CollatorChosen {
-			// 		round: 4,
-			// 		collator_account: collator,
-			// 		total_exposed_amount: 100
-			// 	},
-			// 	Event::CollatorChosen { round: 4, collator_account: 2, total_exposed_amount: 90 },
-			// 	Event::CollatorChosen { round: 4, collator_account: 3, total_exposed_amount: 80 },
-			// 	Event::CollatorChosen { round: 4, collator_account: 4, total_exposed_amount: 70 },
-			// 	Event::NewRound {
-			// 		starting_block: 15,
-			// 		round: 4,
-			// 		selected_collators_number: 4,
-			// 		total_balance: 340,
-			// 	},
-			// );
 			roll_blocks(1);
-			assert_no_events!();
-			roll_blocks(1);
-			assert_no_events!();
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: 1, rewards: 5205 });
-			roll_blocks(1);
-			assert_no_events!();
+			assert_events_eq!(Event::Rewarded { account: collator, rewards: 50000000 });
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6742,53 +6742,9 @@ fn rewards_should_be_constant_when_annual_range_is_fix() {
 			// let's check the first 100 rounds
 			for i in 1..=100 {
 				set_author(i, collator, 100);
-				roll_to_round_begin(i+rewards_delay);
+				roll_to_round_begin(i + rewards_delay);
 				roll_blocks(1);
-				assert_events_eq!(Event::Rewarded { account: collator, rewards: 276 });
+				assert_events_eq!(Event::Rewarded { account: collator, rewards: 69 });
 			}
-		});
-}
-
-#[test]
-fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
-	let governance = 1;
-	let collator = 2;
-	let collator_initial_balance = 10000000;
-	ExtBuilder::default()
-		.with_balances(vec![(governance, 840000000), (collator, collator_initial_balance)])
-		.with_candidates(vec![(collator, 100)])
-		.with_rewards_account(999, 150000000)
-		.with_inflation(InflationInfo {
-			expect: Range { min: 0, ideal: 0, max: 0 },
-			annual: Range {
-				min: Perbill::from_perthousand(75),
-				ideal: Perbill::from_perthousand(75),
-				max: Perbill::from_perthousand(75),
-			},
-			round: Range { min: Perbill::zero(), ideal: Perbill::zero(), max: Perbill::zero() },
-		})
-		.build()
-		.execute_with(|| {
-			set_author(2, collator, 100);
-			set_author(3, collator, 100);
-			set_author(4, collator, 100);
-			roll_to_round_begin(4);
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: collator, rewards: 276 });
-			roll_to_round_begin(5);
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: collator, rewards: 276 });
-			roll_to_round_begin(6);
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: collator, rewards: 276 });
-
-			let blocks_per_round = ParachainStaking::round().length;
-			assert_eq!(blocks_per_round, 5);
-			let blocks_per_year = mock::SlotsPerYear::get();
-			// blocks_per_round = round.length;
-			let rounds_per_year = blocks_per_year / blocks_per_round;
-
-			let all_rewards_per_year = rounds_per_year * 276;
-			assert_eq!(all_rewards_per_year, 290_329_920);
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6724,26 +6724,42 @@ fn test_removed_calls() {
 fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 	let governance = 1;
 	let collator = 2;
+	let collator_initial_balance = 10000000;
 	ExtBuilder::default()
-		.with_balances(vec![(governance, 840000000), (collator, 10000000)])
+		.with_balances(vec![(governance, 840000000), (collator, collator_initial_balance)])
 		.with_candidates(vec![(collator, 100)])
 		.with_rewards_account(999, 150000000)
 		.with_inflation(InflationInfo {
-			expect: Range { min: 700, ideal: 700, max: 700 },
-			// not used
+			expect: Range { min: 0, ideal: 0, max: 0 },
 			annual: Range {
-				min: Perbill::from_perthousand(70),
-				ideal: Perbill::from_perthousand(70),
-				max: Perbill::from_perthousand(70),
+				min: Perbill::from_perthousand(75),
+				ideal: Perbill::from_perthousand(75),
+				max: Perbill::from_perthousand(75),
 			},
-			// unrealistically high parameterization, only for testing
 			round: Range { min: Perbill::zero(), ideal: Perbill::zero(), max: Perbill::zero() },
 		})
 		.build()
 		.execute_with(|| {
 			set_author(2, collator, 100);
+			set_author(3, collator, 100);
+			set_author(4, collator, 100);
 			roll_to_round_begin(4);
 			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: collator, rewards: 258 });
+			assert_events_eq!(Event::Rewarded { account: collator, rewards: 276 });
+			roll_to_round_begin(5);
+			roll_blocks(1);
+			assert_events_eq!(Event::Rewarded { account: collator, rewards: 276 });
+			roll_to_round_begin(6);
+			roll_blocks(1);
+			assert_events_eq!(Event::Rewarded { account: collator, rewards: 276 });
+
+			let blocks_per_round = ParachainStaking::round().length;
+			assert_eq!(blocks_per_round, 5);
+			let blocks_per_year = 31_557_600 / 6; // TODO
+									  // blocks_per_round = round.length;
+			let rounds_per_year = blocks_per_year / blocks_per_round;
+
+			let all_rewards_per_year = rounds_per_year * 276;
+			assert_eq!(all_rewards_per_year, 290_329_920);
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6731,93 +6731,35 @@ fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 		.execute_with(|| {
 			roll_to_round_begin(2);
 			// should choose top TotalCandidatesSelected (5), in order
-			// assert_events_eq!(
-			// 	Event::CollatorChosen { round: 2, collator_account: collator, total_exposed_amount: 100 },
-			// 	Event::CollatorChosen { round: 2, collator_account: 2, total_exposed_amount: 90 },
-			// 	Event::CollatorChosen { round: 2, collator_account: 3, total_exposed_amount: 80 },
-			// 	Event::CollatorChosen { round: 2, collator_account: 4, total_exposed_amount: 70 },
-			// 	Event::NewRound {
-			// 		starting_block: 5,
-			// 		round: 2,
-			// 		selected_collators_number: 4,
-			// 		total_balance: 340,
-			// 	},
-			// );
+			assert_events_eq!(
+				Event::CollatorChosen { round: 2, collator_account: collator, total_exposed_amount: 100 },
+				Event::CollatorChosen { round: 2, collator_account: 2, total_exposed_amount: 90 },
+				Event::CollatorChosen { round: 2, collator_account: 3, total_exposed_amount: 80 },
+				Event::CollatorChosen { round: 2, collator_account: 4, total_exposed_amount: 70 },
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 4,
+					total_balance: 340,
+				},
+			);
 			// ~ set block author as 1 for all blocks this round
 			set_author(2, collator, 100);
 			roll_to_round_begin(4);
-			// assert_events_eq!(
-			// 	Event::CollatorChosen { round: 4, collator_account: collator, total_exposed_amount: 100 },
-			// 	Event::CollatorChosen { round: 4, collator_account: 2, total_exposed_amount: 90 },
-			// 	Event::CollatorChosen { round: 4, collator_account: 3, total_exposed_amount: 80 },
-			// 	Event::CollatorChosen { round: 4, collator_account: 4, total_exposed_amount: 70 },
-			// 	Event::NewRound {
-			// 		starting_block: 15,
-			// 		round: 4,
-			// 		selected_collators_number: 4,
-			// 		total_balance: 340,
-			// 	},
-			// );
+			assert_events_eq!(
+				Event::CollatorChosen { round: 4, collator_account: collator, total_exposed_amount: 100 },
+				Event::CollatorChosen { round: 4, collator_account: 2, total_exposed_amount: 90 },
+				Event::CollatorChosen { round: 4, collator_account: 3, total_exposed_amount: 80 },
+				Event::CollatorChosen { round: 4, collator_account: 4, total_exposed_amount: 70 },
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 4,
+					total_balance: 340,
+				},
+			);
 			// pay total issuance to 1 at 2nd block
 			roll_blocks(3);
 			assert_events_eq!(Event::Rewarded { account: 1, rewards: 5205 });
-			return;
-			// ~ set block author as 1 for 3 blocks this round
-			set_author(4, collator, 60);
-			// ~ set block author as 2 for 2 blocks this round
-			set_author(4, 2, 40);
-			roll_to_round_begin(6);
-			// pay 60% total issuance to 1 and 40% total issuance to 2
-			assert_events_eq!(
-				Event::CollatorChosen { round: 6, collator_account: collator, total_exposed_amount: 100 },
-				Event::CollatorChosen { round: 6, collator_account: 2, total_exposed_amount: 90 },
-				Event::CollatorChosen { round: 6, collator_account: 3, total_exposed_amount: 80 },
-				Event::CollatorChosen { round: 6, collator_account: 4, total_exposed_amount: 70 },
-				Event::NewRound {
-					starting_block: 25,
-					round: 6,
-					selected_collators_number: 4,
-					total_balance: 340,
-				},
-			);
-			roll_blocks(3);
-			assert_events_eq!(Event::Rewarded { account: collator, rewards: 3123 });
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: 2, rewards: 2082 },);
-			// ~ each collator produces 1 block this round
-			set_author(6, collator, 20);
-			set_author(6, 2, 20);
-			set_author(6, 3, 20);
-			set_author(6, 4, 20);
-			roll_to_round_begin(8);
-			// pay 20% issuance for all collators
-			assert_events_eq!(
-				Event::CollatorChosen { round: 8, collator_account: collator, total_exposed_amount: 100 },
-				Event::CollatorChosen { round: 8, collator_account: 2, total_exposed_amount: 90 },
-				Event::CollatorChosen { round: 8, collator_account: 3, total_exposed_amount: 80 },
-				Event::CollatorChosen { round: 8, collator_account: 4, total_exposed_amount: 70 },
-				Event::NewRound {
-					starting_block: 35,
-					round: 8,
-					selected_collators_number: 4,
-					total_balance: 340,
-				},
-			);
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: 3, rewards: 1301 });
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: 4, rewards: 1301 });
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: 1, rewards: 1301 });
-			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: 2, rewards: 1301 });
-			// check that distributing rewards clears awarded pts
-			assert!(ParachainStaking::awarded_pts(1, 1).is_zero());
-			assert!(ParachainStaking::awarded_pts(4, 1).is_zero());
-			assert!(ParachainStaking::awarded_pts(4, 2).is_zero());
-			assert!(ParachainStaking::awarded_pts(6, 1).is_zero());
-			assert!(ParachainStaking::awarded_pts(6, 2).is_zero());
-			assert!(ParachainStaking::awarded_pts(6, 3).is_zero());
-			assert!(ParachainStaking::awarded_pts(6, 4).is_zero());
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6719,3 +6719,104 @@ fn test_removed_calls() {
 		);
 	});
 }
+
+#[test]
+fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
+	let collator = 1;
+	ExtBuilder::default()
+		.with_balances(vec![(collator, 1000), (2, 1000), (3, 1000), (4, 1000), (7, 33), (8, 33), (9, 33)])
+		.with_candidates(vec![(collator, 100), (2, 90), (3, 80), (4, 70)])
+		.with_rewards_account(999, 100000)
+		.build()
+		.execute_with(|| {
+			roll_to_round_begin(2);
+			// should choose top TotalCandidatesSelected (5), in order
+			assert_events_eq!(
+				Event::CollatorChosen { round: 2, collator_account: collator, total_exposed_amount: 100 },
+				Event::CollatorChosen { round: 2, collator_account: 2, total_exposed_amount: 90 },
+				Event::CollatorChosen { round: 2, collator_account: 3, total_exposed_amount: 80 },
+				Event::CollatorChosen { round: 2, collator_account: 4, total_exposed_amount: 70 },
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 4,
+					total_balance: 340,
+				},
+			);
+			// ~ set block author as 1 for all blocks this round
+			set_author(2, collator, 100);
+			roll_to_round_begin(4);
+			assert_events_eq!(
+				Event::CollatorChosen { round: 4, collator_account: collator, total_exposed_amount: 100 },
+				Event::CollatorChosen { round: 4, collator_account: 2, total_exposed_amount: 90 },
+				Event::CollatorChosen { round: 4, collator_account: 3, total_exposed_amount: 80 },
+				Event::CollatorChosen { round: 4, collator_account: 4, total_exposed_amount: 70 },
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 4,
+					total_balance: 340,
+				},
+			);
+			// pay total issuance to 1 at 2nd block
+			roll_blocks(3);
+			assert_events_eq!(Event::Rewarded { account: 1, rewards: 5205 });
+			// ~ set block author as 1 for 3 blocks this round
+			set_author(4, collator, 60);
+			// ~ set block author as 2 for 2 blocks this round
+			set_author(4, 2, 40);
+			roll_to_round_begin(6);
+			// pay 60% total issuance to 1 and 40% total issuance to 2
+			assert_events_eq!(
+				Event::CollatorChosen { round: 6, collator_account: collator, total_exposed_amount: 100 },
+				Event::CollatorChosen { round: 6, collator_account: 2, total_exposed_amount: 90 },
+				Event::CollatorChosen { round: 6, collator_account: 3, total_exposed_amount: 80 },
+				Event::CollatorChosen { round: 6, collator_account: 4, total_exposed_amount: 70 },
+				Event::NewRound {
+					starting_block: 25,
+					round: 6,
+					selected_collators_number: 4,
+					total_balance: 340,
+				},
+			);
+			roll_blocks(3);
+			assert_events_eq!(Event::Rewarded { account: collator, rewards: 3123 });
+			roll_blocks(1);
+			assert_events_eq!(Event::Rewarded { account: 2, rewards: 2082 },);
+			// ~ each collator produces 1 block this round
+			set_author(6, collator, 20);
+			set_author(6, 2, 20);
+			set_author(6, 3, 20);
+			set_author(6, 4, 20);
+			roll_to_round_begin(8);
+			// pay 20% issuance for all collators
+			assert_events_eq!(
+				Event::CollatorChosen { round: 8, collator_account: collator, total_exposed_amount: 100 },
+				Event::CollatorChosen { round: 8, collator_account: 2, total_exposed_amount: 90 },
+				Event::CollatorChosen { round: 8, collator_account: 3, total_exposed_amount: 80 },
+				Event::CollatorChosen { round: 8, collator_account: 4, total_exposed_amount: 70 },
+				Event::NewRound {
+					starting_block: 35,
+					round: 8,
+					selected_collators_number: 4,
+					total_balance: 340,
+				},
+			);
+			roll_blocks(1);
+			assert_events_eq!(Event::Rewarded { account: 3, rewards: 1301 });
+			roll_blocks(1);
+			assert_events_eq!(Event::Rewarded { account: 4, rewards: 1301 });
+			roll_blocks(1);
+			assert_events_eq!(Event::Rewarded { account: 1, rewards: 1301 });
+			roll_blocks(1);
+			assert_events_eq!(Event::Rewarded { account: 2, rewards: 1301 });
+			// check that distributing rewards clears awarded pts
+			assert!(ParachainStaking::awarded_pts(1, 1).is_zero());
+			assert!(ParachainStaking::awarded_pts(4, 1).is_zero());
+			assert!(ParachainStaking::awarded_pts(4, 2).is_zero());
+			assert!(ParachainStaking::awarded_pts(6, 1).is_zero());
+			assert!(ParachainStaking::awarded_pts(6, 2).is_zero());
+			assert!(ParachainStaking::awarded_pts(6, 3).is_zero());
+			assert!(ParachainStaking::awarded_pts(6, 4).is_zero());
+		});
+}

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6759,7 +6759,7 @@ fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 				},
 			);
 			// pay total issuance to 1 at 2nd block
-			roll_blocks(3);
+			roll_blocks(1);
 			assert_events_eq!(Event::Rewarded { account: 1, rewards: 5205 });
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6731,36 +6731,37 @@ fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 		.execute_with(|| {
 			roll_to_round_begin(2);
 			// should choose top TotalCandidatesSelected (5), in order
-			assert_events_eq!(
-				Event::CollatorChosen { round: 2, collator_account: collator, total_exposed_amount: 100 },
-				Event::CollatorChosen { round: 2, collator_account: 2, total_exposed_amount: 90 },
-				Event::CollatorChosen { round: 2, collator_account: 3, total_exposed_amount: 80 },
-				Event::CollatorChosen { round: 2, collator_account: 4, total_exposed_amount: 70 },
-				Event::NewRound {
-					starting_block: 5,
-					round: 2,
-					selected_collators_number: 4,
-					total_balance: 340,
-				},
-			);
+			// assert_events_eq!(
+			// 	Event::CollatorChosen { round: 2, collator_account: collator, total_exposed_amount: 100 },
+			// 	Event::CollatorChosen { round: 2, collator_account: 2, total_exposed_amount: 90 },
+			// 	Event::CollatorChosen { round: 2, collator_account: 3, total_exposed_amount: 80 },
+			// 	Event::CollatorChosen { round: 2, collator_account: 4, total_exposed_amount: 70 },
+			// 	Event::NewRound {
+			// 		starting_block: 5,
+			// 		round: 2,
+			// 		selected_collators_number: 4,
+			// 		total_balance: 340,
+			// 	},
+			// );
 			// ~ set block author as 1 for all blocks this round
 			set_author(2, collator, 100);
 			roll_to_round_begin(4);
-			assert_events_eq!(
-				Event::CollatorChosen { round: 4, collator_account: collator, total_exposed_amount: 100 },
-				Event::CollatorChosen { round: 4, collator_account: 2, total_exposed_amount: 90 },
-				Event::CollatorChosen { round: 4, collator_account: 3, total_exposed_amount: 80 },
-				Event::CollatorChosen { round: 4, collator_account: 4, total_exposed_amount: 70 },
-				Event::NewRound {
-					starting_block: 15,
-					round: 4,
-					selected_collators_number: 4,
-					total_balance: 340,
-				},
-			);
+			// assert_events_eq!(
+			// 	Event::CollatorChosen { round: 4, collator_account: collator, total_exposed_amount: 100 },
+			// 	Event::CollatorChosen { round: 4, collator_account: 2, total_exposed_amount: 90 },
+			// 	Event::CollatorChosen { round: 4, collator_account: 3, total_exposed_amount: 80 },
+			// 	Event::CollatorChosen { round: 4, collator_account: 4, total_exposed_amount: 70 },
+			// 	Event::NewRound {
+			// 		starting_block: 15,
+			// 		round: 4,
+			// 		selected_collators_number: 4,
+			// 		total_balance: 340,
+			// 	},
+			// );
 			// pay total issuance to 1 at 2nd block
 			roll_blocks(3);
 			assert_events_eq!(Event::Rewarded { account: 1, rewards: 5205 });
+			return;
 			// ~ set block author as 1 for 3 blocks this round
 			set_author(4, collator, 60);
 			// ~ set block author as 2 for 2 blocks this round

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -26,9 +26,9 @@ use crate::{
 	auto_compound::{AutoCompoundConfig, AutoCompoundDelegations},
 	delegation_requests::{CancelledScheduledRequest, DelegationAction, ScheduledRequest},
 	mock::{
-		assert_events_emitted, assert_events_emitted_match, assert_events_eq, assert_no_events,
-		roll_blocks, roll_to, roll_to_round_begin, roll_to_round_end, set_author, set_block_author,
-		Balances, BlockNumber, ExtBuilder, ParachainStaking, RuntimeOrigin, Test,
+		self, assert_events_emitted, assert_events_emitted_match, assert_events_eq,
+		assert_no_events, roll_blocks, roll_to, roll_to_round_begin, roll_to_round_end, set_author,
+		set_block_author, Balances, BlockNumber, ExtBuilder, ParachainStaking, RuntimeOrigin, Test,
 	},
 	AtStake, Bond, CollatorStatus, DelegationScheduledRequests, DelegatorAdded,
 	EnableMarkingOffline, Error, Event, InflationInfo, Range, DELEGATOR_LOCK_ID,
@@ -6755,8 +6755,8 @@ fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 
 			let blocks_per_round = ParachainStaking::round().length;
 			assert_eq!(blocks_per_round, 5);
-			let blocks_per_year = 31_557_600 / 6; // TODO
-									  // blocks_per_round = round.length;
+			let blocks_per_year = mock::SlotsPerYear::get();
+			// blocks_per_round = round.length;
 			let rounds_per_year = blocks_per_year / blocks_per_round;
 
 			let all_rewards_per_year = rounds_per_year * 276;

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -31,7 +31,7 @@ use crate::{
 		Balances, BlockNumber, ExtBuilder, ParachainStaking, RuntimeOrigin, Test,
 	},
 	AtStake, Bond, CollatorStatus, DelegationScheduledRequests, DelegatorAdded,
-	EnableMarkingOffline, Error, Event, Range, DELEGATOR_LOCK_ID,
+	EnableMarkingOffline, Error, Event, InflationInfo, Range, DELEGATOR_LOCK_ID,
 };
 use frame_support::{assert_err, assert_noop, assert_ok, pallet_prelude::*, BoundedVec};
 use sp_runtime::{traits::Zero, DispatchError, ModuleError, Perbill, Percent};
@@ -6728,11 +6728,22 @@ fn test_the_rewards_will_be_the_correct_one_calculated_from_the_yearly_rate() {
 		.with_balances(vec![(governance, 840000000), (collator, 10000000)])
 		.with_candidates(vec![(collator, 100)])
 		.with_rewards_account(999, 150000000)
+		.with_inflation(InflationInfo {
+			expect: Range { min: 700, ideal: 700, max: 700 },
+			// not used
+			annual: Range {
+				min: Perbill::from_perthousand(70),
+				ideal: Perbill::from_perthousand(70),
+				max: Perbill::from_perthousand(70),
+			},
+			// unrealistically high parameterization, only for testing
+			round: Range { min: Perbill::zero(), ideal: Perbill::zero(), max: Perbill::zero() },
+		})
 		.build()
 		.execute_with(|| {
 			set_author(2, collator, 100);
 			roll_to_round_begin(4);
 			roll_blocks(1);
-			assert_events_eq!(Event::Rewarded { account: collator, rewards: 50000000 });
+			assert_events_eq!(Event::Rewarded { account: collator, rewards: 258 });
 		});
 }


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Refactored inflation configuration setup in `pallets/parachain-staking/src/lib.rs` to ensure it's set after round initialization.
- Introduced a `SlotsPerYear` constant in `pallets/parachain-staking/src/mock.rs` for better configuration management.
- Added a new test in `pallets/parachain-staking/src/tests.rs` to ensure rewards remain constant over 100 rounds with a fixed annual inflation range.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Refactor Inflation Configuration Setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pallets/parachain-staking/src/lib.rs
<li>Removed inflation configuration setting from the initial setup phase.<br> <li> Added inflation configuration setting after the round initialization.<br> <li> This change ensures inflation configuration is set after the round <br>details are established.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/469/files#diff-842251b834245800808bd740184c1e3b18c6af1f95fb1bd4d484420017fdf86e">+12/-11</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mock.rs</strong><dd><code>Introduce SlotsPerYear Constant for Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pallets/parachain-staking/src/mock.rs
<li>Introduced a new constant <code>SlotsPerYear</code> for easier modification and <br>readability.<br> <li> Replaced the hardcoded value for <code>SlotsPerYear</code> with the new constant.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/469/files#diff-75e5a84c910859aa75adb95f11e6d0b0a1a4d4e8fa742c0ac366f524a7134929">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs</strong><dd><code>Add Test for Constant Rewards with Fixed Annual Inflation Range</code></dd></summary>
<hr>

pallets/parachain-staking/src/tests.rs
<li>Added a new test <code>rewards_should_be_constant_when_annual_range_is_fix</code>.<br> <li> This test verifies that rewards remain constant over 100 rounds when <br>the annual inflation range is fixed.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/469/files#diff-a2fcd9e2ec1e588e9fcfed674d8d0058713d685aaba3ed374ba248d4c279e02f">+33/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

