### PR TITLE
Enhance Staking Config with Accurate Slot Time Calculation

### DIFF
--- a/runtime/laos/src/configs/parachain_staking.rs
+++ b/runtime/laos/src/configs/parachain_staking.rs
@@ -1,5 +1,5 @@
 use crate::{
-	currency::UNIT, AccountId, Balances, BlockNumber, Permill, Runtime, RuntimeEvent, Vec, Weight,
+	currency::UNIT, AccountId, Balances, BlockNumber, Permill, Runtime, RuntimeEvent, Vec, Weight, MILLISECS_PER_BLOCK
 };
 use frame_support::{parameter_types, traits::Get};
 use frame_system::EnsureRoot;
@@ -7,6 +7,8 @@ use pallet_parachain_staking::{self as staking, rewards, Config as StakingConfig
 use pallet_session::{SessionManager, ShouldEndSession};
 use sp_consensus_slots::Slot;
 use sp_staking::SessionIndex;
+
+const SECONDS_PER_BLOCK: u32 = MILLISECS_PER_BLOCK as u32 / 1000;
 
 // Define runtime constants used across the parachain staking configuration.
 parameter_types! {
@@ -25,7 +27,7 @@ parameter_types! {
 	pub const MaxDelegationsPerDelegator: u32 = 100; // Max delegations per delegator.
 	pub const MinDelegation: u128 = 500 * UNIT; // Minimum stake to be a delegator.
 	pub const MaxCandidates: u32 = 200; // Max candidates allowed.
-	pub const SlotsPerYear: u32 = 31_557_600 / 12; // Number of slots per year.
+	pub const SlotsPerYear: u32 = 31_557_600 / SECONDS_PER_BLOCK; // Number of slots per year.
 }
 
 // Implementing the configuration trait for the parachain staking pallet.
@@ -54,9 +56,9 @@ impl StakingConfig for Runtime {
 	type OnInactiveCollator = (); // Placeholder for future implementation.
 	type OnNewRound = (); // Placeholder for future implementation.
 	type SlotProvider = StakingRoundSlotProvider;
-	type WeightInfo = staking::weights::SubstrateWeight<Runtime>;
 	type MaxCandidates = MaxCandidates;
 	type SlotsPerYear = SlotsPerYear;
+	type WeightInfo = staking::weights::SubstrateWeight<Runtime>;
 }
 
 // Custom struct for identifying the block author.
@@ -153,7 +155,7 @@ impl frame_support::traits::EstimateNextSessionRotation<BlockNumber> for Paracha
 mod tests {
 	use super::{MinCandidateStk, MinDelegation, MinSelectedCandidates};
 	use crate::{
-		configs::parachain_staking::{MinBlocksPerRound, ParachainStakingAdapter},
+		configs::parachain_staking::{MinBlocksPerRound, ParachainStakingAdapter, SlotsPerYear},
 		tests::ExtBuilder,
 		Balances, ParachainStaking, RuntimeOrigin, System,
 	};
@@ -319,5 +321,10 @@ mod tests {
 			let (next_session, _) = ParachainStakingAdapter::estimate_next_session_rotation(1);
 			assert_eq!(next_session, Some(MinBlocksPerRound::get() as u32));
 		});
+	}
+
+	#[test]
+	fn test_slot_per_year() {
+		assert_eq!(SlotsPerYear::get(), 31_557_600 / 12);
 	}
 }

--- a/runtime/laos/src/configs/parachain_staking.rs
+++ b/runtime/laos/src/configs/parachain_staking.rs
@@ -1,5 +1,6 @@
 use crate::{
-	currency::UNIT, AccountId, Balances, BlockNumber, Permill, Runtime, RuntimeEvent, Vec, Weight, MILLISECS_PER_BLOCK
+	currency::UNIT, AccountId, Balances, BlockNumber, Permill, Runtime, RuntimeEvent, Vec, Weight,
+	MILLISECS_PER_BLOCK,
 };
 use frame_support::{parameter_types, traits::Get};
 use frame_system::EnsureRoot;


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced `MILLISECS_PER_BLOCK` and `SECONDS_PER_BLOCK` for accurate block time calculations in staking configurations.
- Updated `SlotsPerYear` calculation to use `SECONDS_PER_BLOCK`, improving the accuracy of slot time calculations.
- Added a new unit test `test_slot_per_year` to validate the correctness of the `SlotsPerYear` calculation.
- Performed minor refactoring and adjustments in the parachain staking configuration and implementation for clarity and efficiency.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parachain_staking.rs</strong><dd><code>Enhance Parachain Staking Configuration with Accurate Slot Calculation</code></dd></summary>
<hr>

runtime/laos/src/configs/parachain_staking.rs
<li>Introduced <code>MILLISECS_PER_BLOCK</code> and <code>SECONDS_PER_BLOCK</code> to calculate <br>block times.<br> <li> Updated <code>SlotsPerYear</code> to use <code>SECONDS_PER_BLOCK</code> for more accurate slot <br>calculation.<br> <li> Added a new test <code>test_slot_per_year</code> to ensure <code>SlotsPerYear</code> calculation <br>is correct.<br> <li> Minor adjustments and refactoring in staking configuration parameters <br>and implementation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/475/files#diff-260a47c783c16f4ca58a07f9d05998e138f42333640d8c0e48b7df110a0143d8">+11/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

