### PR TITLE
Enhance WeightInfo Assignments and Configurations in Runtime

### DIFF
--- a/runtime/laos/src/configs/balances.rs
+++ b/runtime/laos/src/configs/balances.rs
@@ -25,11 +25,11 @@ impl pallet_balances::Config for Runtime {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 	type MaxReserves = MaxReserves;
 	type ReserveIdentifier = [u8; 8];
 	type FreezeIdentifier = RuntimeFreezeReason;
 	type MaxHolds = MaxHolds;
 	type RuntimeHoldReason = ();
 	type MaxFreezes = MaxFreezes;
+	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/laos/src/configs/cumulus_xcmp_queue.rs
+++ b/runtime/laos/src/configs/cumulus_xcmp_queue.rs
@@ -13,6 +13,6 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
 	type ControllerOrigin = EnsureRoot<AccountId>;
 	type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
-	type WeightInfo = (); // TODO
 	type PriceForSiblingDelivery = ();
+	type WeightInfo = cumulus_pallet_xcmp_queue::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/laos/src/configs/evm.rs
+++ b/runtime/laos/src/configs/evm.rs
@@ -44,9 +44,9 @@ impl pallet_evm::Config for Runtime {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type RuntimeEvent = RuntimeEvent;
 	type Timestamp = Timestamp;
-	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 	type WeightPerGas = WeightPerGas;
 	type WithdrawOrigin = pallet_evm::EnsureAddressNever<AccountId>;
+	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }
 
 pub struct CustomFindAuthor<Inner>(sp_std::marker::PhantomData<Inner>);

--- a/runtime/laos/src/configs/sudo.rs
+++ b/runtime/laos/src/configs/sudo.rs
@@ -3,5 +3,5 @@ use crate::{Runtime, RuntimeCall, RuntimeEvent};
 impl pallet_sudo::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type WeightInfo = ();
+	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/laos/src/configs/transaction_payment.rs
+++ b/runtime/laos/src/configs/transaction_payment.rs
@@ -25,7 +25,6 @@ impl WeightToFeePolynomial for LengthToFee {
 	}
 }
 
-// TODO: following has to be checked with this: https://github.com/moonbeam-foundation/moonbeam/blob/31dd0f3703d844b139a2f0fafde91025a8b97771/runtime/moonbeam/src/lib.rs#L361
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type OnChargeTransaction =

--- a/runtime/laos/src/configs/vesting.rs
+++ b/runtime/laos/src/configs/vesting.rs
@@ -2,7 +2,6 @@ use crate::{currency::UNIT, Balance, Balances, Runtime, RuntimeEvent};
 use frame_support::{parameter_types, traits::WithdrawReasons};
 use sp_runtime::traits::ConvertInto;
 
-// Configuration of the Vesting Pallet
 parameter_types! {
 	pub const MinVestedTransfer: Balance = UNIT;
 	pub UnvestedFundsAllowedWithdrawReasons: WithdrawReasons =
@@ -10,11 +9,12 @@ parameter_types! {
 }
 
 impl pallet_vesting::Config for Runtime {
+	const MAX_VESTING_SCHEDULES: u32 = 28;
+
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type BlockNumberToBalance = ConvertInto;
-	type WeightInfo = pallet_vesting::weights::SubstrateWeight<Runtime>;
 	type MinVestedTransfer = MinVestedTransfer;
 	type UnvestedFundsAllowedWithdrawReasons = UnvestedFundsAllowedWithdrawReasons;
-	const MAX_VESTING_SCHEDULES: u32 = 28;
+	type WeightInfo = pallet_vesting::weights::SubstrateWeight<Runtime>;
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Implemented and refactored `WeightInfo` type assignments across various configs for clarity and consistency.
- Increased `MAX_VESTING_SCHEDULES` in the vesting config to 28.
- Removed outdated TODO comment in transaction payment config.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>balances.rs</strong><dd><code>Refactor WeightInfo Assignment in Balances Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/balances.rs
- Moved `WeightInfo` type assignment for clarity.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/476/files#diff-c273ea519032c05d3509a3f28ccd2774398547ba43aae662dad536091c754b66">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cumulus_xcmp_queue.rs</strong><dd><code>Implement WeightInfo for XCMP Queue Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/cumulus_xcmp_queue.rs
- Added `WeightInfo` type assignment to use `SubstrateWeight`.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/476/files#diff-cddc5de870ba2ea110c4b0b6cad78cf776f0f66d0cce7e50bcfea5c4ca060c80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Refactor WeightInfo Assignment in EVM Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/evm.rs
- Moved `WeightInfo` type assignment for clarity.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/476/files#diff-705ca1a21913654f820d021a4ab6d046d975864f252f68537584e89bcd379518">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sudo.rs</strong><dd><code>Implement WeightInfo for Sudo Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/sudo.rs
- Added `WeightInfo` type assignment to use `SubstrateWeight`.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/476/files#diff-177513dc454934ffb1585263edbdfa35a53af5ea0dcc16871ec651b948b19b35">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_payment.rs</strong><dd><code>Cleanup in Transaction Payment Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/transaction_payment.rs
- Removed outdated TODO comment.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/476/files#diff-618e168b86d01d0a9042850498c7f4b1ff5032ae1914cb13c5995b63763fce84">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vesting.rs</strong><dd><code>Update and Refactor Vesting Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/vesting.rs
<li>Increased <code>MAX_VESTING_SCHEDULES</code> to 28.<br> <li> Moved <code>WeightInfo</code> type assignment for clarity.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/476/files#diff-6c67f5e1403fa2826cc5e3e12726ef7f73ca98c69b6ade8edba8d8dceecd3cb5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

