### PR TITLE
Enhance Currency Constants and Fee Structure in Laos Runtime

### DIFF
--- a/runtime/laos/src/configs/transaction_payment.rs
+++ b/runtime/laos/src/configs/transaction_payment.rs
@@ -1,5 +1,5 @@
 use crate::{
-	currency::{TRANSACTION_BYTE_FEE, WEIGHT_FEE},
+	currency::{TRANSACTION_BYTE_FEE, WEIGHT_TO_FEE},
 	types::ToAuthor,
 	Balance, Balances, Runtime, RuntimeEvent,
 };
@@ -30,7 +30,7 @@ impl pallet_transaction_payment::Config for Runtime {
 	type OnChargeTransaction =
 		pallet_transaction_payment::CurrencyAdapter<Balances, ToAuthor<Self>>;
 	type OperationalFeeMultiplier = ConstU8<5>;
-	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ WEIGHT_FEE }>>;
+	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ WEIGHT_TO_FEE }>>;
 	type LengthToFee = LengthToFee;
 	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 }
@@ -50,7 +50,7 @@ mod tests {
 			pallet_transaction_payment::Pallet::<Runtime>::weight_to_fee(
 				frame_support::weights::Weight::from_parts(1, 0)
 			),
-			WEIGHT_FEE
+			WEIGHT_TO_FEE
 		);
 		// in case weight to fee exceeds max_block
 		assert_eq!(
@@ -58,7 +58,7 @@ mod tests {
 				frame_support::weights::Weight::from_parts(u64::MAX, 0)
 			),
 			<Runtime as frame_system::Config>::BlockWeights::get().max_block.ref_time() as u128 *
-				WEIGHT_FEE
+				WEIGHT_TO_FEE
 		);
 	}
 

--- a/runtime/laos/src/configs/transaction_payment.rs
+++ b/runtime/laos/src/configs/transaction_payment.rs
@@ -1,5 +1,5 @@
 use crate::{
-	currency::{TRANSACTION_BYTE_FEE, WEIGHT_TO_FEE},
+	currency::{TRANSACTION_BYTE_FEE, WEIGHT_FEE},
 	types::ToAuthor,
 	Balance, Balances, Runtime, RuntimeEvent,
 };
@@ -30,7 +30,7 @@ impl pallet_transaction_payment::Config for Runtime {
 	type OnChargeTransaction =
 		pallet_transaction_payment::CurrencyAdapter<Balances, ToAuthor<Self>>;
 	type OperationalFeeMultiplier = ConstU8<5>;
-	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ WEIGHT_TO_FEE }>>;
+	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ WEIGHT_FEE }>>;
 	type LengthToFee = LengthToFee;
 	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 }
@@ -50,7 +50,7 @@ mod tests {
 			pallet_transaction_payment::Pallet::<Runtime>::weight_to_fee(
 				frame_support::weights::Weight::from_parts(1, 0)
 			),
-			WEIGHT_TO_FEE
+			WEIGHT_FEE
 		);
 		// in case weight to fee exceeds max_block
 		assert_eq!(
@@ -58,7 +58,7 @@ mod tests {
 				frame_support::weights::Weight::from_parts(u64::MAX, 0)
 			),
 			<Runtime as frame_system::Config>::BlockWeights::get().max_block.ref_time() as u128 *
-				WEIGHT_TO_FEE
+				WEIGHT_FEE
 		);
 	}
 

--- a/runtime/laos/src/currency.rs
+++ b/runtime/laos/src/currency.rs
@@ -4,24 +4,20 @@ use laos_primitives::Balance;
 // 18 decimals
 pub(crate) const UNIT: Balance = 1_000_000_000_000_000_000;
 pub(crate) const MILLIUNIT: Balance = UNIT / 1000;
+pub(crate) const MICROUNIT: Balance = MILLIUNIT / 1000;
 
 // Constants in ETH terms
-pub(crate) const WEI: Balance = 1;
 pub(crate) const KILOWEI: Balance = 1_000;
+pub const MEGAWEI: Balance = 1_000_000;
 pub(crate) const GIGAWEI: Balance = 1_000_000_000;
 
-// Define storage fees as constants for clarity and reuse
 const STORAGE_ITEM_FEE: Balance = 10 * UNIT;
-const STORAGE_BYTE_FEE: Balance = 10 * MILLIUNIT;
+pub(crate) const STORAGE_BYTE_FEE: Balance = 10 * MILLIUNIT;
+pub(crate) const TRANSACTION_BYTE_FEE: Balance = 100 * GIGAWEI;
+pub(crate) const WEIGHT_FEE: Balance = 5 * MEGAWEI;
 
-/// One byte of transaction data has a fee of 1/1000 of a micro unit.
-pub(crate) const TRANSACTION_BYTE_FEE: Balance = 1 * GIGAWEI;
-/// Weight to fee conversion factor.
-pub(crate) const WEIGHT_TO_FEE: u128 = 50 * KILOWEI;
-
-/// Calculates the deposit required based on the number of items and bytes.
 pub(crate) const fn calculate_deposit(items: u32, bytes: u32) -> Balance {
-	(items as Balance) * STORAGE_ITEM_FEE + (bytes as Balance) * STORAGE_BYTE_FEE
+	items as Balance * STORAGE_ITEM_FEE + (bytes as Balance) * STORAGE_BYTE_FEE
 }
 
 #[cfg(test)]

--- a/runtime/laos/src/currency.rs
+++ b/runtime/laos/src/currency.rs
@@ -3,7 +3,7 @@ use laos_primitives::Balance;
 // Unit = the base number of indivisible units for balances
 // 18 decimals
 pub(crate) const UNIT: Balance = 1_000_000_000_000_000_000;
-pub(crate) const MILLIUNIT: Balance = 1_000_000_000_000_000;
+pub(crate) const MILLIUNIT: Balance = UNIT / 1_000;
 
 // Constants in ETH terms
 const MEGAWEI: Balance = 1_000_000;
@@ -11,7 +11,10 @@ const GIGAWEI: Balance = 1_000_000_000;
 
 const STORAGE_ITEM_FEE: Balance = 10 * UNIT;
 const STORAGE_BYTE_FEE: Balance = 10 * MILLIUNIT;
+
+/// One byte of transaction data has a fee of 100 GigaWei.
 pub(crate) const TRANSACTION_BYTE_FEE: Balance = 100 * GIGAWEI;
+/// Weight to fee conversion factor.
 pub(crate) const WEIGHT_TO_FEE: Balance = 5 * MEGAWEI;
 
 pub(crate) const fn calculate_deposit(items: u32, bytes: u32) -> Balance {

--- a/runtime/laos/src/currency.rs
+++ b/runtime/laos/src/currency.rs
@@ -4,15 +4,13 @@ use laos_primitives::Balance;
 // 18 decimals
 pub(crate) const UNIT: Balance = 1_000_000_000_000_000_000;
 pub(crate) const MILLIUNIT: Balance = UNIT / 1000;
-pub(crate) const MICROUNIT: Balance = MILLIUNIT / 1000;
 
 // Constants in ETH terms
-pub(crate) const KILOWEI: Balance = 1_000;
-pub const MEGAWEI: Balance = 1_000_000;
-pub(crate) const GIGAWEI: Balance = 1_000_000_000;
+const MEGAWEI: Balance = 1_000_000;
+const GIGAWEI: Balance = 1_000_000_000;
 
 const STORAGE_ITEM_FEE: Balance = 10 * UNIT;
-pub(crate) const STORAGE_BYTE_FEE: Balance = 10 * MILLIUNIT;
+const STORAGE_BYTE_FEE: Balance = 10 * MILLIUNIT;
 pub(crate) const TRANSACTION_BYTE_FEE: Balance = 100 * GIGAWEI;
 pub(crate) const WEIGHT_FEE: Balance = 5 * MEGAWEI;
 

--- a/runtime/laos/src/currency.rs
+++ b/runtime/laos/src/currency.rs
@@ -7,8 +7,8 @@ pub(crate) const MILLIUNIT: Balance = UNIT / 1000;
 
 // Constants in ETH terms
 pub(crate) const WEI: Balance = 1;
-pub(crate) const KILOWEI: Balance = 1_000 * WEI;
-pub(crate) const GIGAWEI: Balance = 1_000_000_000 * WEI;
+pub(crate) const KILOWEI: Balance = 1_000;
+pub(crate) const GIGAWEI: Balance = 1_000_000_000;
 
 // Define storage fees as constants for clarity and reuse
 const STORAGE_ITEM_FEE: Balance = 10 * UNIT;

--- a/runtime/laos/src/currency.rs
+++ b/runtime/laos/src/currency.rs
@@ -12,7 +12,7 @@ const GIGAWEI: Balance = 1_000_000_000;
 const STORAGE_ITEM_FEE: Balance = 10 * UNIT;
 const STORAGE_BYTE_FEE: Balance = 10 * MILLIUNIT;
 pub(crate) const TRANSACTION_BYTE_FEE: Balance = 100 * GIGAWEI;
-pub(crate) const WEIGHT_FEE: Balance = 5 * MEGAWEI;
+pub(crate) const WEIGHT_TO_FEE: Balance = 5 * MEGAWEI;
 
 pub(crate) const fn calculate_deposit(items: u32, bytes: u32) -> Balance {
 	items as Balance * STORAGE_ITEM_FEE + (bytes as Balance) * STORAGE_BYTE_FEE

--- a/runtime/laos/src/currency.rs
+++ b/runtime/laos/src/currency.rs
@@ -3,7 +3,7 @@ use laos_primitives::Balance;
 // Unit = the base number of indivisible units for balances
 // 18 decimals
 pub(crate) const UNIT: Balance = 1_000_000_000_000_000_000;
-pub(crate) const MILLIUNIT: Balance = UNIT / 1000;
+pub(crate) const MILLIUNIT: Balance = 1_000_000_000_000_000;
 
 // Constants in ETH terms
 const MEGAWEI: Balance = 1_000_000;


### PR DESCRIPTION
## **User description**
| Network | issuance | SUPPLY_FACTOR |
|----------|----------|----------|
|Moonbeam| 1B| 100|
|Moonriver|11M|1|
|Moonbase|...|1|

I will use 100 as multiplier factor cause LAOS issuance is 1B


___

## **Type**
enhancement


___

## **Description**
- Removed unused constants (`WEI`, `KILOWEI`) and introduced `MEGAWEI` for clarity and simplicity.
- Updated `TRANSACTION_BYTE_FEE` and `WEIGHT_TO_FEE` to reflect new fee structure, enhancing transaction cost clarity.
- Simplified the `calculate_deposit` function, improving code readability.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>currency.rs</strong><dd><code>Refactor Currency Constants and Fee Calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/currency.rs
<li>Removed <code>WEI</code> and <code>KILOWEI</code> constants, introducing <code>MEGAWEI</code>.<br> <li> Adjusted <code>TRANSACTION_BYTE_FEE</code> and <code>WEIGHT_TO_FEE</code> constants to use <br><code>GIGAWEI</code> and <code>MEGAWEI</code> respectively.<br> <li> Simplified <code>calculate_deposit</code> function by removing unnecessary type <br>casting.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/480/files#diff-beed98a83eae9fc121a869c258d6e6494d3d957616671866da798cd2053f2237">+5/-11</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

