### PR TITLE
Remove Unused Migration Type Alias from Runtime Configuration

### DIFF
--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -83,8 +83,6 @@ pub type UncheckedExtrinsic =
 pub type CheckedExtrinsic =
 	fp_self_contained::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra, H160>;
 
-type Migrations = precompiles::migration::InjectDamePrecompileBytecode<Runtime>; // TODO check if this is correct
-
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
 	Runtime,
@@ -92,7 +90,6 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	Migrations,
 >;
 
 pub type Precompiles = FrontierPrecompiles<Runtime>;


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed an unused migration type alias from the runtime configuration, simplifying the codebase.
- This change streamlines the `Executive` type definition by removing an unnecessary parameter.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Remove Unused Migration Type Alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs
<li>Removed the <code>Migrations</code> type alias which was used to inject Dame <br>precompile bytecode.<br> <li> Updated the <code>Executive</code> type to no longer use the <code>Migrations</code> type alias.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/485/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

