### PR TITLE
Refactor and Improve Visibility of ChainSpec in Laos Runtime

### DIFF
--- a/node/src/chain_spec/laos.rs
+++ b/node/src/chain_spec/laos.rs
@@ -7,7 +7,8 @@ use laos_runtime::{
 use sc_service::ChainType;
 use sp_runtime::Perbill;
 
-pub(crate) type ChainSpec = sc_service::GenericChainSpec<laos_runtime::RuntimeGenesisConfig, Extensions>;
+pub(crate) type ChainSpec =
+	sc_service::GenericChainSpec<laos_runtime::RuntimeGenesisConfig, Extensions>;
 
 pub(crate) fn development_config() -> ChainSpec {
 	generic_chain_config("Development", "dev", ChainType::Development, None)

--- a/node/src/chain_spec/laos.rs
+++ b/node/src/chain_spec/laos.rs
@@ -7,13 +7,13 @@ use laos_runtime::{
 use sc_service::ChainType;
 use sp_runtime::Perbill;
 
-pub type ChainSpec = sc_service::GenericChainSpec<laos_runtime::RuntimeGenesisConfig, Extensions>;
+pub(crate) type ChainSpec = sc_service::GenericChainSpec<laos_runtime::RuntimeGenesisConfig, Extensions>;
 
-pub fn development_config() -> ChainSpec {
+pub(crate) fn development_config() -> ChainSpec {
 	generic_chain_config("Development", "dev", ChainType::Development, None)
 }
 
-pub fn local_testnet_config() -> ChainSpec {
+pub(crate) fn local_testnet_config() -> ChainSpec {
 	generic_chain_config(
 		"Local Testnet",
 		"laos_local_testnet",


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed an unused import to clean up the code.
- Changed the visibility of several items to `pub(crate)` to restrict their scope within the crate.
- Introduced two new constants for easier configuration and maintenance of parachain and EVM chain IDs.
- Refactored configuration functions to reduce code duplication and improve clarity.
- Simplified the genesis configuration function for better readability and maintenance.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>laos.rs</strong><dd><code>Refactor ChainSpec Definitions and Visibility in Laos Chain Spec</code></dd></summary>
<hr>

node/src/chain_spec/laos.rs
<li>Removed unused import <code>cumulus_primitives_core::ParaId</code>.<br> <li> Changed visibility of <code>ChainSpec</code> and configuration functions to <br><code>pub(crate)</code>.<br> <li> Introduced constants <code>PARA_ID</code> and <code>EVM_CHAIN_ID</code> for parachain and EVM <br>chain IDs.<br> <li> Refactored <code>development_config</code> and <code>local_testnet_config</code> functions to <br>use a new helper function <code>generic_chain_config</code>.<br> <li> Simplified <code>create_test_genesis_config</code> function by removing the <code>id</code> <br>parameter and using <code>PARA_ID</code> directly.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/487/files#diff-2ccef9e2947edd74c86ff7b5a814c38a09079830181b3f5d86bb098384e7a868">+36/-29</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

