### PR TITLE
Simplify `Timestamp` Module Declaration in Runtime Configuration

### DIFF
--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -146,7 +146,7 @@ construct_runtime!(
 		// System support stuff.
 		System: frame_system = 0,
 		ParachainSystem: cumulus_pallet_parachain_system = 1,
-		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent} = 2,
+		Timestamp: pallet_timestamp = 2,
 		ParachainInfo: parachain_info = 3,
 		Sudo: pallet_sudo = 4,
 		Utility: pallet_utility = 5,


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Simplified the `Timestamp` module declaration in the runtime configuration, removing explicit mentions of `Pallet`, `Call`, `Storage`, and `Inherent` to use a minimal declaration style.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Simplification of Module Declaration in Runtime</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs
- Simplified the declaration of `Timestamp` module in the runtime.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/490/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

