### PR TITLE
Enhance Configurability and Simplify Runtime

### DIFF
--- a/node/src/chain_spec/laos.rs
+++ b/node/src/chain_spec/laos.rs
@@ -1,6 +1,7 @@
 use super::{get_collator_keys_from_seed, predefined_accounts, Extensions, SAFE_XCM_VERSION};
 use fp_evm::GenesisAccount;
 use laos_runtime::{
+	configs::system::SS58Prefix,
 	currency::{DECIMALS, UNIT},
 	AuraId, Precompiles, REVERT_BYTECODE,
 };
@@ -38,7 +39,7 @@ fn properties() -> sc_chain_spec::Properties {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "UNIT".into());
 	properties.insert("tokenDecimals".into(), DECIMALS.into());
-	properties.insert("ss58Format".into(), 42.into());
+	properties.insert("ss58Format".into(), SS58Prefix::get().into());
 	properties
 }
 

--- a/runtime/laos/src/configs/mod.rs
+++ b/runtime/laos/src/configs/mod.rs
@@ -17,7 +17,7 @@ pub mod parachain_staking;
 mod proxy;
 mod session;
 mod sudo;
-mod system;
+pub mod system;
 mod timestamp;
 mod transaction_payment;
 mod utility;

--- a/runtime/laos/src/configs/parachain_staking.rs
+++ b/runtime/laos/src/configs/parachain_staking.rs
@@ -9,6 +9,7 @@ use pallet_session::{SessionManager, ShouldEndSession};
 use sp_consensus_slots::Slot;
 use sp_staking::SessionIndex;
 
+const SECONDS_PER_YEAR: u32 = 31_557_600;
 const SECONDS_PER_BLOCK: u32 = MILLISECS_PER_BLOCK as u32 / 1000;
 
 // Define runtime constants used across the parachain staking configuration.
@@ -28,7 +29,7 @@ parameter_types! {
 	pub const MaxDelegationsPerDelegator: u32 = 100; // Max delegations per delegator.
 	pub const MinDelegation: u128 = 500 * UNIT; // Minimum stake to be a delegator.
 	pub const MaxCandidates: u32 = 200; // Max candidates allowed.
-	pub const SlotsPerYear: u32 = 31_557_600 / SECONDS_PER_BLOCK; // Number of slots per year.
+	pub const SlotsPerYear: u32 = SECONDS_PER_YEAR / SECONDS_PER_BLOCK; // Number of slots per year.
 }
 
 // Implementing the configuration trait for the parachain staking pallet.

--- a/runtime/laos/src/configs/timestamp.rs
+++ b/runtime/laos/src/configs/timestamp.rs
@@ -1,6 +1,6 @@
 use crate::{Aura, Runtime, MILLISECS_PER_BLOCK};
-
 use frame_support::parameter_types;
+
 parameter_types! {
 	pub const MinimumPeriod: u64 = MILLISECS_PER_BLOCK / 2;
 }

--- a/runtime/laos/src/configs/transaction_payment.rs
+++ b/runtime/laos/src/configs/transaction_payment.rs
@@ -3,12 +3,14 @@ use crate::{
 	types::ToAuthor,
 	Balance, Balances, Runtime, RuntimeEvent,
 };
-use frame_support::weights::{
-	ConstantMultiplier, WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
+use frame_support::{
+	parameter_types,
+	weights::{
+		ConstantMultiplier, WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
+	},
 };
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use smallvec::smallvec;
-use sp_core::{ConstU128, ConstU8};
 use sp_runtime::Perbill;
 
 pub struct LengthToFee;
@@ -33,12 +35,17 @@ impl WeightToFeePolynomial for LengthToFee {
 	}
 }
 
+parameter_types! {
+	pub const OperationalFeeMultiplier: u8 = 5;
+	pub const WeightToFee: u128 = WEIGHT_TO_FEE;
+}
+
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type OnChargeTransaction =
 		pallet_transaction_payment::CurrencyAdapter<Balances, ToAuthor<Self>>;
-	type OperationalFeeMultiplier = ConstU8<5>;
-	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ WEIGHT_TO_FEE }>>;
+	type OperationalFeeMultiplier = OperationalFeeMultiplier;
+	type WeightToFee = ConstantMultiplier<Balance, WeightToFee>;
 	type LengthToFee = LengthToFee;
 	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 }

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -172,8 +172,7 @@ construct_runtime!(
 		Ethereum: pallet_ethereum = 50,
 		EVM: pallet_evm = 51,
 		EVMChainId: pallet_evm_chain_id = 52,
-		// DynamicFee: pallet_dynamic_fee = 43,
-		BaseFee: pallet_base_fee = 54,
+		BaseFee: pallet_base_fee = 53,
 
 		// LAOS pallets
 		LaosEvolution: pallet_laos_evolution = 100,

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -157,10 +157,10 @@ construct_runtime!(
 
 		// Consensus support: the order of these 5 are important and shall not change.
 		Authorship: pallet_authorship = 20,
-		Session: pallet_session = 22,
-		Aura: pallet_aura = 23,
-		AuraExt: cumulus_pallet_aura_ext = 24,
-		ParachainStaking: pallet_parachain_staking = 25,
+		Session: pallet_session = 21,
+		Aura: pallet_aura = 22,
+		AuraExt: cumulus_pallet_aura_ext = 23,
+		ParachainStaking: pallet_parachain_staking = 24,
 
 		// XCM helpers.
 		XcmpQueue: cumulus_pallet_xcmp_queue = 30,

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -54,40 +54,8 @@ use xcm_config::{XcmConfig, XcmOriginToTransactDispatchOrigin};
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 
-/// A Block signed with a Justification
-pub type SignedBlock = generic::SignedBlock<Block>;
-
 /// BlockId type as expected by this runtime.
 pub type BlockId = generic::BlockId<Block>;
-
-/// The SignedExtension to the basic transaction logic.
-pub type SignedExtra = (
-	frame_system::CheckNonZeroSender<Runtime>,
-	frame_system::CheckSpecVersion<Runtime>,
-	frame_system::CheckTxVersion<Runtime>,
-	frame_system::CheckGenesis<Runtime>,
-	frame_system::CheckEra<Runtime>,
-	frame_system::CheckNonce<Runtime>,
-	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-);
-
-/// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic =
-	fp_self_contained::UncheckedExtrinsic<AccountId, RuntimeCall, Signature, SignedExtra>;
-
-/// Extrinsic type that has already been checked.
-pub type CheckedExtrinsic =
-	fp_self_contained::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra, H160>;
-
-/// Executive: handles dispatch to the various modules.
-pub type Executive = frame_executive::Executive<
-	Runtime,
-	Block,
-	frame_system::ChainContext<Runtime>,
-	Runtime,
-	AllPalletsWithSystem,
->;
 
 pub type Precompiles = FrontierPrecompiles<Runtime>;
 
@@ -114,6 +82,9 @@ impl_opaque_keys! {
 	}
 }
 
+/// This determines the average expected block time that we are targeting.
+pub const MILLISECS_PER_BLOCK: u64 = 12000;
+
 /// Version of the runtime
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -126,9 +97,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	transaction_version: 1,
 	state_version: 1,
 };
-
-/// This determines the average expected block time that we are targeting.
-pub const MILLISECS_PER_BLOCK: u64 = 12000;
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
@@ -181,6 +149,31 @@ construct_runtime!(
 );
 
 impl_runtime_apis_plus!();
+
+/// The SignedExtension to the basic transaction logic.
+type SignedExtra = (
+	frame_system::CheckNonZeroSender<Runtime>,
+	frame_system::CheckSpecVersion<Runtime>,
+	frame_system::CheckTxVersion<Runtime>,
+	frame_system::CheckGenesis<Runtime>,
+	frame_system::CheckEra<Runtime>,
+	frame_system::CheckNonce<Runtime>,
+	frame_system::CheckWeight<Runtime>,
+	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+);
+
+/// Unchecked extrinsic type as expected by this runtime.
+type UncheckedExtrinsic =
+	fp_self_contained::UncheckedExtrinsic<AccountId, RuntimeCall, Signature, SignedExtra>;
+
+/// Executive: handles dispatch to the various modules.
+type Executive = frame_executive::Executive<
+	Runtime,
+	Block,
+	frame_system::ChainContext<Runtime>,
+	Runtime,
+	AllPalletsWithSystem,
+>;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced dynamic SS58 prefix configuration in chain spec, enhancing network flexibility.
- Exposed the system module publicly for broader module access.
- Refactored parachain staking and transaction payment configurations for better clarity and configurability.
- Simplified runtime by removing unused types and adjusting pallet order to fix a runtime pallet order issue.
- Minor formatting adjustment in timestamp configuration for consistency.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>laos.rs</strong><dd><code>Dynamic SS58 Prefix Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

node/src/chain_spec/laos.rs
<li>Introduced <code>SS58Prefix</code> configuration to dynamically set <code>ss58Format</code>.<br> <li> Removed hardcoded <code>ss58Format</code> value, enhancing flexibility.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/497/files#diff-2ccef9e2947edd74c86ff7b5a814c38a09079830181b3f5d86bb098384e7a868">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Expose System Module Publicly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/mod.rs
- Made `system` module public to allow access from other modules.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/497/files#diff-450b756d1af9090dd62cc432c3c21a1a4f655d52ee8b477c3d81e1038434d68b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>parachain_staking.rs</strong><dd><code>Refactor Parachain Staking Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/parachain_staking.rs
<li>Introduced <code>SECONDS_PER_YEAR</code> constant for clarity in <code>SlotsPerYear</code> <br>calculation.<br> <li> Enhanced readability and maintainability in parachain staking <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/497/files#diff-260a47c783c16f4ca58a07f9d05998e138f42333640d8c0e48b7df110a0143d8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_payment.rs</strong><dd><code>Refactor Transaction Payment Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/transaction_payment.rs
<li>Refactored transaction payment configuration using <code>parameter_types</code>.<br> <li> Introduced <code>OperationalFeeMultiplier</code> and <code>WeightToFee</code> parameters for <br>better configurability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/497/files#diff-618e168b86d01d0a9042850498c7f4b1ff5032ae1914cb13c5995b63763fce84">+12/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>timestamp.rs</strong><dd><code>Timestamp Configuration Formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/timestamp.rs
- Minor formatting adjustment for consistency.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/497/files#diff-205e42d22950dadd246e9f93923a76c32d9fa258a8c71b6b034c392d8ba1148c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Runtime Simplification and Pallet Order Fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs
<li>Simplified runtime type definitions by removing unused types.<br> <li> Adjusted pallet order to fix runtime pallet order issue.<br> <li> Introduced <code>MILLISECS_PER_BLOCK</code> constant for block time configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/497/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+33/-41</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

