### PR TITLE
Refactor Runtime Configurations and Improve Module Organization

### DIFF
--- a/runtime/laos/src/configs/cumulus_aura_ext.rs
+++ b/runtime/laos/src/configs/cumulus_aura_ext.rs
@@ -1,3 +1,0 @@
-use crate::Runtime;
-
-impl cumulus_pallet_aura_ext::Config for Runtime {}

--- a/runtime/laos/src/configs/cumulus_dmp_queue.rs
+++ b/runtime/laos/src/configs/cumulus_dmp_queue.rs
@@ -1,4 +1,6 @@
-use crate::{AccountId, EnsureRoot, Runtime, RuntimeEvent, XcmConfig, XcmExecutor};
+use crate::{AccountId, EnsureRoot, Runtime, RuntimeEvent, XcmExecutor};
+
+use super::xcm_config::XcmConfig;
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/runtime/laos/src/configs/cumulus_xcmp_queue.rs
+++ b/runtime/laos/src/configs/cumulus_xcmp_queue.rs
@@ -1,7 +1,6 @@
-use crate::{
-	AccountId, ParachainSystem, Runtime, RuntimeEvent, XcmConfig, XcmExecutor,
-	XcmOriginToTransactDispatchOrigin,
-};
+use crate::{AccountId, ParachainSystem, Runtime, RuntimeEvent, XcmExecutor};
+
+use super::xcm_config::{XcmConfig, XcmOriginToTransactDispatchOrigin};
 
 use frame_system::EnsureRoot;
 

--- a/runtime/laos/src/configs/evm_chain_id.rs
+++ b/runtime/laos/src/configs/evm_chain_id.rs
@@ -1,3 +1,0 @@
-use crate::Runtime;
-
-impl pallet_evm_chain_id::Config for Runtime {}

--- a/runtime/laos/src/configs/mod.rs
+++ b/runtime/laos/src/configs/mod.rs
@@ -3,17 +3,14 @@ mod aura;
 mod authorship;
 mod balances;
 mod base_fee;
-mod cumulus_aura_ext;
 mod cumulus_dmp_queue;
 mod cumulus_parachain_system;
 mod cumulus_xcmp_queue;
 mod ethereum;
 mod evm;
-mod evm_chain_id;
 mod laos_evolution;
 mod multisig;
-mod parachain_info;
-pub mod parachain_staking;
+pub(crate) mod parachain_staking;
 mod proxy;
 mod session;
 mod sudo;
@@ -22,11 +19,17 @@ mod timestamp;
 mod transaction_payment;
 mod utility;
 mod vesting;
-pub mod xcm_config;
+pub(crate) mod xcm_config;
 
 use frame_support::parameter_types;
+
+use crate::Runtime;
 
 parameter_types! {
 	/// Max length of the `TokenUri`
 	pub const MaxTokenUriLength: u32 = 512;
 }
+
+impl cumulus_pallet_aura_ext::Config for Runtime {}
+impl pallet_evm_chain_id::Config for Runtime {}
+impl parachain_info::Config for Runtime {}

--- a/runtime/laos/src/configs/mod.rs
+++ b/runtime/laos/src/configs/mod.rs
@@ -22,6 +22,7 @@ mod timestamp;
 mod transaction_payment;
 mod utility;
 mod vesting;
+pub mod xcm_config;
 
 use frame_support::parameter_types;
 

--- a/runtime/laos/src/configs/parachain_info.rs
+++ b/runtime/laos/src/configs/parachain_info.rs
@@ -1,3 +1,0 @@
-use crate::Runtime;
-
-impl parachain_info::Config for Runtime {}

--- a/runtime/laos/src/configs/xcm_config.rs
+++ b/runtime/laos/src/configs/xcm_config.rs
@@ -1,4 +1,4 @@
-use super::{
+use crate::{
 	types::ToAuthor, AccountId, AllPalletsWithSystem, Balances, ParachainInfo, PolkadotXcm,
 	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
 };

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -11,7 +11,6 @@ mod precompiles;
 mod self_contained_call;
 pub mod types;
 mod weights;
-pub mod xcm_config;
 
 use core::marker::PhantomData;
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
@@ -34,7 +33,6 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use staging_xcm_executor::XcmExecutor;
-use xcm_config::{XcmConfig, XcmOriginToTransactDispatchOrigin};
 
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Refactored the configuration modules for the runtime, improving code organization and module visibility.
- Removed unused `Config` implementations for `cumulus_aura_ext`, `evm_chain_id`, and `parachain_info`.
- Consolidated `XcmConfig` and related types into the `xcm_config` module, enhancing code maintainability.
- Adjusted the runtime library structure for clarity and better module management.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cumulus_aura_ext.rs</strong><dd><code>Remove cumulus_aura_ext Config Implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/cumulus_aura_ext.rs
<li>Removed <code>cumulus_pallet_aura_ext::Config</code> implementation for <code>Runtime</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/512/files#diff-4c63a60a9cf4e46e2c8005aa9b26d9da31c20c2c5c112020d24ad0b69e814fc8">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cumulus_dmp_queue.rs</strong><dd><code>Refactor cumulus_dmp_queue Config Imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/cumulus_dmp_queue.rs
<li>Removed direct use of <code>XcmConfig</code>.<br> <li> Imported <code>XcmConfig</code> from <code>xcm_config</code> module.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/512/files#diff-19323aac1bb660241e346e856b671482f8db5ad5493aa3f05fe9e77ed2ed21f3">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cumulus_xcmp_queue.rs</strong><dd><code>Refactor cumulus_xcmp_queue Config Imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/cumulus_xcmp_queue.rs
<li>Removed direct use of <code>XcmConfig</code> and <code>XcmOriginToTransactDispatchOrigin</code>.<br> <li> Imported <code>XcmConfig</code> and <code>XcmOriginToTransactDispatchOrigin</code> from <br><code>xcm_config</code> module.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/512/files#diff-cddc5de870ba2ea110c4b0b6cad78cf776f0f66d0cce7e50bcfea5c4ca060c80">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>evm_chain_id.rs</strong><dd><code>Remove evm_chain_id Config Implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/evm_chain_id.rs
<li>Removed <code>pallet_evm_chain_id::Config</code> implementation for <code>Runtime</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/512/files#diff-3d2245d849087efe8a979d0b3632a679d0cce10a778f28e7e61c07d5642b3238">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Refactor Config Modules and Implementations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/mod.rs
<li>Removed unused config modules: <code>cumulus_aura_ext</code>, <code>evm_chain_id</code>, <br><code>parachain_info</code>.<br> <li> Changed visibility of <code>parachain_staking</code> and <code>xcm_config</code> modules to <br><code>pub(crate)</code>.<br> <li> Added implementations for <code>cumulus_pallet_aura_ext::Config</code>, <br><code>pallet_evm_chain_id::Config</code>, and <code>parachain_info::Config</code> for <code>Runtime</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/512/files#diff-450b756d1af9090dd62cc432c3c21a1a4f655d52ee8b477c3d81e1038434d68b">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>parachain_info.rs</strong><dd><code>Remove parachain_info Config Implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/parachain_info.rs
- Removed `parachain_info::Config` implementation for `Runtime`.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/512/files#diff-9579b501861ed1c3c9d53ab5b03350ef6e86b6cdeb2c661aa375a4a9978c7f59">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>xcm_config.rs</strong><dd><code>Refactor xcm_config Imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/xcm_config.rs
- Changed the import path for various types from `super` to `crate`.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/512/files#diff-7be85ebadbdf1d1e426a2b4f3e4f1d6b496df8603fa762c7e0efcceb40533a48">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Adjust Runtime Library Structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs
<li>Removed <code>xcm_config</code> module exposure.<br> <li> Minor adjustments to imports and code structure.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/512/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

