### PR TITLE
Refactor mock runtimes to use `DefaultConfig` for system and balances

### DIFF
--- a/pallets/asset-metadata-extender/src/mock.rs
+++ b/pallets/asset-metadata-extender/src/mock.rs
@@ -1,14 +1,7 @@
 use crate as pallet_asset_metadata_extender;
-use frame_support::{
-	parameter_types,
-	traits::{ConstU16, ConstU64},
-	weights::constants::RocksDbWeight,
-};
-use sp_core::{H160, H256};
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage,
-};
+use frame_support::{derive_impl, parameter_types};
+use sp_core::H160;
+use sp_runtime::{traits::IdentityLookup, BuildStorage};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -23,30 +16,11 @@ frame_support::construct_runtime!(
 
 type AccountId = H160;
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = RocksDbWeight;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Block = Block;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = ();
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ConstU16<42>;
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 parameter_types! {

--- a/pallets/laos-evolution/src/mock.rs
+++ b/pallets/laos-evolution/src/mock.rs
@@ -1,14 +1,7 @@
 use crate as pallet_laos_evolution;
-use frame_support::{
-	parameter_types,
-	traits::{ConstU16, ConstU64},
-	weights::constants::RocksDbWeight,
-};
-use sp_core::{H160, H256};
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage,
-};
+use frame_support::{derive_impl, parameter_types};
+use sp_core::H160;
+use sp_runtime::{traits::IdentityLookup, BuildStorage};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -23,30 +16,11 @@ frame_support::construct_runtime!(
 
 pub type AccountId = H160;
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = RocksDbWeight;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Block = Block;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = ();
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ConstU16<42>;
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 parameter_types! {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -22,18 +22,15 @@ use crate::{
 };
 use block_author::BlockAuthor as BlockAuthorMap;
 use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{Everything, Get, LockIdentifier, OnFinalize, OnInitialize},
+	construct_runtime, derive_impl, parameter_types,
+	traits::{Get, LockIdentifier, OnFinalize, OnInitialize},
 	weights::{constants::RocksDbWeight, Weight},
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use sp_consensus_slots::Slot;
-use sp_core::H256;
+use sp_core::ConstU32;
 use sp_io;
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage, Perbill, Percent,
-};
+use sp_runtime::{traits::IdentityLookup, BuildStorage, Perbill, Percent};
 
 pub use test_utils::*;
 
@@ -55,55 +52,35 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = Weight::from_parts(1024, 1);
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 	pub const SS58Prefix: u8 = 42;
 }
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-	type BaseCallFilter = Everything;
-	type DbWeight = RocksDbWeight;
-	type RuntimeOrigin = RuntimeOrigin;
-	type Nonce = u64;
 	type Block = Block;
-	type RuntimeCall = RuntimeCall;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = BlockHashCount;
-	type Version = ();
-	type PalletInfo = PalletInfo;
+	type BlockHashCount = ConstU32<250>;
 	type AccountData = pallet_balances::AccountData<Balance>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type BlockWeights = ();
-	type BlockLength = ();
-	type SS58Prefix = SS58Prefix;
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type DbWeight = RocksDbWeight;
 }
+
 parameter_types! {
 	pub const ExistentialDeposit: u128 = 0;
 }
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Test {
-	type MaxReserves = ();
-	type ReserveIdentifier = [u8; 4];
-	type MaxLocks = ();
 	type Balance = Balance;
-	type RuntimeEvent = RuntimeEvent;
-	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type WeightInfo = ();
 	type RuntimeHoldReason = ();
-	type FreezeIdentifier = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
+	type DustRemoval = ();
 }
+
 impl block_author::Config for Test {}
 const GENESIS_BLOCKS_PER_ROUND: BlockNumber = 5;
 const GENESIS_COLLATOR_COMMISSION: Perbill = Perbill::from_percent(20);

--- a/precompile/asset-metadata-extender/src/mock.rs
+++ b/precompile/asset-metadata-extender/src/mock.rs
@@ -1,16 +1,10 @@
 use core::str::FromStr;
 use fp_evm::{Precompile, PrecompileHandle};
 use frame_support::{
-	parameter_types,
-	traits::{ConstU16, ConstU64, FindAuthor},
-	weights::constants::RocksDbWeight,
+	derive_impl, parameter_types, traits::FindAuthor, weights::constants::RocksDbWeight,
 };
-use pallet_balances::AccountData;
-use sp_core::{H160, H256, U256};
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage, ConsensusEngineId,
-};
+use sp_core::{H160, U256};
+use sp_runtime::{traits::IdentityLookup, BuildStorage, ConsensusEngineId};
 
 use crate::AssetMetadataExtenderPrecompile;
 
@@ -26,34 +20,32 @@ frame_support::construct_runtime!(
 	}
 );
 
+type AccountId = H160;
+type Balance = u64;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = RocksDbWeight;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Block = Block;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = AccountData<u64>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ConstU16<42>;
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type DbWeight = RocksDbWeight;
+	type AccountData = pallet_balances::AccountData<Balance>;
 }
 
-type AccountId = H160;
-type Block = frame_system::mocking::MockBlock<Test>;
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 0;
+}
+
+// Pallet Balances
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
+impl pallet_balances::Config for Test {
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type RuntimeHoldReason = ();
+	type DustRemoval = ();
+	type Balance = Balance;
+}
 
 // Pallet Asset Metadata Extender
 impl pallet_asset_metadata_extender::Config for Test {
@@ -145,27 +137,6 @@ where
 	fn is_precompile(&self, _address: H160, _gas: u64) -> fp_evm::IsPrecompileResult {
 		return fp_evm::IsPrecompileResult::Answer { is_precompile: true, extra_cost: 0 }
 	}
-}
-
-// Pallet Balances
-impl pallet_balances::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type Balance = u64;
-	type DustRemoval = ();
-	type ExistentialDeposit = ExistentialDeposit;
-	type AccountStore = System;
-	type ReserveIdentifier = ();
-	type RuntimeHoldReason = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
-}
-
-parameter_types! {
-	pub const ExistentialDeposit: u64 = 0;
 }
 
 // Pallet Timestamp

--- a/precompile/evolution-collection-factory/src/mock.rs
+++ b/precompile/evolution-collection-factory/src/mock.rs
@@ -6,16 +6,10 @@ use sp_runtime::BuildStorage;
 use crate::EvolutionCollectionFactoryPrecompile;
 
 use frame_support::{
-	parameter_types,
-	traits::{ConstU16, ConstU64, FindAuthor},
-	weights::constants::RocksDbWeight,
+	derive_impl, parameter_types, traits::FindAuthor, weights::constants::RocksDbWeight,
 };
-use pallet_balances::AccountData;
-use sp_core::{H160, H256, U256};
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
-	ConsensusEngineId,
-};
+use sp_core::{H160, U256};
+use sp_runtime::{traits::IdentityLookup, ConsensusEngineId};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -31,31 +25,15 @@ frame_support::construct_runtime!(
 );
 
 pub type AccountId = H160;
+type Balance = u64;
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = RocksDbWeight;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Block = Block;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = AccountData<u64>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ConstU16<42>;
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type DbWeight = RocksDbWeight;
 }
 
 parameter_types! {
@@ -79,20 +57,13 @@ impl pallet_laos_evolution::Config for Test {
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 0;
 }
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type Balance = u64;
-	type DustRemoval = ();
+	type Balance = Balance;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type ReserveIdentifier = ();
 	type RuntimeHoldReason = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
+	type DustRemoval = ();
 }
 
 parameter_types! {

--- a/precompile/evolution-collection/src/mock.rs
+++ b/precompile/evolution-collection/src/mock.rs
@@ -8,16 +8,10 @@ use sp_runtime::BuildStorage;
 use crate::EvolutionCollectionPrecompile;
 
 use frame_support::{
-	parameter_types,
-	traits::{ConstU16, ConstU64, FindAuthor},
-	weights::constants::RocksDbWeight,
+	derive_impl, parameter_types, traits::FindAuthor, weights::constants::RocksDbWeight,
 };
-use pallet_balances::AccountData;
-use sp_core::{H160, H256, U256};
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
-	ConsensusEngineId,
-};
+use sp_core::{H160, U256};
+use sp_runtime::{traits::IdentityLookup, ConsensusEngineId};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -33,31 +27,28 @@ frame_support::construct_runtime!(
 );
 
 pub type AccountId = H160;
+type Balance = u64;
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = RocksDbWeight;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Block = Block;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = AccountData<u64>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ConstU16<42>;
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type DbWeight = RocksDbWeight;
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 0;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type RuntimeHoldReason = ();
+	type DustRemoval = ();
 }
 
 parameter_types! {
@@ -76,25 +67,6 @@ impl pallet_laos_evolution::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type AccountIdToH160 = AccountIdToH160;
 	type MaxTokenUriLength = MaxTokenUriLength;
-}
-
-parameter_types! {
-	pub const ExistentialDeposit: u64 = 0;
-}
-impl pallet_balances::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type Balance = u64;
-	type DustRemoval = ();
-	type ExistentialDeposit = ExistentialDeposit;
-	type AccountStore = System;
-	type ReserveIdentifier = ();
-	type RuntimeHoldReason = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
 }
 
 parameter_types! {

--- a/runtime/klaos/src/precompiles/mock.rs
+++ b/runtime/klaos/src/precompiles/mock.rs
@@ -1,16 +1,14 @@
 use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{ConstU64, FindAuthor},
-	weights::Weight,
+	construct_runtime, derive_impl, parameter_types, traits::FindAuthor, weights::Weight,
 };
 use pallet_evm::{
 	runner, EnsureAddressNever, EnsureAddressRoot, FeeCalculator, FixedGasWeightMapping,
 	IdentityAddressMapping, SubstrateBlockHashMapping,
 };
 
-use sp_core::{H160, H256, U256};
+use sp_core::{H160, U256};
 use sp_runtime::{
-	traits::{BlakeTwo256, Convert, IdentityLookup},
+	traits::{Convert, IdentityLookup},
 	ConsensusEngineId,
 };
 use sp_std::{boxed::Box, prelude::*, str::FromStr};
@@ -18,6 +16,7 @@ use sp_std::{boxed::Box, prelude::*, str::FromStr};
 use super::FrontierPrecompiles;
 
 type Block = frame_system::mocking::MockBlock<Runtime>;
+type Balance = u128;
 type AccountId = H160;
 
 // Configure a mock runtime to test the pallet.
@@ -30,50 +29,25 @@ construct_runtime!(
 	}
 );
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = pallet_balances::AccountData<u128>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ();
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type Nonce = u64;
-	type Block = Block;
+	type AccountData = pallet_balances::AccountData<Balance>;
 }
 
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
 }
 
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type Balance = u128;
-	type DustRemoval = ();
+	type Balance = Balance;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type ReserveIdentifier = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
 	type RuntimeHoldReason = ();
+	type DustRemoval = ();
 }
 
 parameter_types! {

--- a/runtime/klaos/src/tests/xcm_mock/parachain.rs
+++ b/runtime/klaos/src/tests/xcm_mock/parachain.rs
@@ -9,10 +9,9 @@ use cumulus_primitives_core::{
 	MultiAsset, MultiLocation, NetworkId, Plurality, XcmContext, XcmError,
 };
 use frame_support::{
-	construct_runtime, match_types, parameter_types,
+	construct_runtime, derive_impl, match_types, parameter_types,
 	traits::{
-		AsEnsureOriginWithArg, ConstU64, Currency, Everything, FindAuthor, Nothing, OnUnbalanced,
-		OriginTrait,
+		AsEnsureOriginWithArg, Currency, Everything, FindAuthor, Nothing, OnUnbalanced, OriginTrait,
 	},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 	PalletId,
@@ -32,12 +31,10 @@ use orml_traits::{
 use pallet_xcm::XcmPassthrough;
 use parity_scale_codec::Encode;
 use polkadot_parachain_primitives::primitives::Sibling;
-use sp_core::{ConstU128, ConstU32, H160, H256, U256};
+use sp_core::{ConstU128, ConstU32, H160, U256};
 use sp_io::storage;
 use sp_runtime::{
-	traits::{
-		AccountIdConversion, BlakeTwo256, Convert, IdentityLookup, MaybeEquivalence, TryConvert,
-	},
+	traits::{AccountIdConversion, Convert, IdentityLookup, MaybeEquivalence, TryConvert},
 	ConsensusEngineId,
 };
 use sp_std::{boxed::Box, prelude::*, str::FromStr};
@@ -79,50 +76,26 @@ construct_runtime!(
 	}
 );
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<Balance>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ();
-	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type Nonce = u64;
-	type Block = Block;
+	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Runtime>;
 }
 
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 0;
 }
 
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
 	type Balance = Balance;
-	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type ReserveIdentifier = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
 	type RuntimeHoldReason = ();
+	type DustRemoval = ();
 }
 
 parameter_types! {

--- a/runtime/klaos/src/tests/xcm_mock/relay_chain.rs
+++ b/runtime/klaos/src/tests/xcm_mock/relay_chain.rs
@@ -1,12 +1,11 @@
 //! Mock Kusama relay chain runtime.
 
 use frame_support::{
-	construct_runtime, parameter_types,
+	construct_runtime, derive_impl, parameter_types,
 	traits::{ConstU32, Everything, Nothing, ProcessMessage, ProcessMessageError},
 	weights::{Weight, WeightMeter},
 };
 use frame_system::EnsureRoot;
-use sp_core::H256;
 use sp_runtime::{traits::IdentityLookup, AccountId32};
 
 use polkadot_parachain_primitives::primitives::Id as ParaId;
@@ -40,55 +39,32 @@ construct_runtime!(
 
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
+	pub const MaxLocks: u32 = 50;
+	pub const MaxReserves: u32 = 50;
 }
 pub type Block = frame_system::mocking::MockBlock<Runtime>;
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
-	type Hash = H256;
-	type Hashing = ::sp_runtime::traits::BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = BlockHashCount;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type Version = ();
-	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<Balance>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type DbWeight = ();
-	type BaseCallFilter = Everything;
-	type SystemWeightInfo = ();
-	type SS58Prefix = ();
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type Block = Block;
 }
 
 parameter_types! {
 	pub ExistentialDeposit: Balance = 1;
-	pub const MaxLocks: u32 = 50;
-	pub const MaxReserves: u32 = 50;
 }
 
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
 	type Balance = Balance;
-	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type ReserveIdentifier = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
 	type RuntimeHoldReason = ();
+	type DustRemoval = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = MaxReserves;
 }
 
 impl shared::Config for Runtime {}

--- a/runtime/laos/src/precompiles/mock.rs
+++ b/runtime/laos/src/precompiles/mock.rs
@@ -1,16 +1,14 @@
 use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{ConstU64, FindAuthor},
-	weights::Weight,
+	construct_runtime, derive_impl, parameter_types, traits::FindAuthor, weights::Weight,
 };
 use pallet_evm::{
 	runner, EnsureAddressNever, EnsureAddressRoot, FeeCalculator, FixedGasWeightMapping,
 	IdentityAddressMapping, SubstrateBlockHashMapping,
 };
 
-use sp_core::{H160, H256, U256};
+use sp_core::{H160, U256};
 use sp_runtime::{
-	traits::{BlakeTwo256, Convert, IdentityLookup},
+	traits::{Convert, IdentityLookup},
 	ConsensusEngineId,
 };
 use sp_std::{boxed::Box, prelude::*, str::FromStr};
@@ -19,6 +17,7 @@ use super::FrontierPrecompiles;
 
 type Block = frame_system::mocking::MockBlock<Runtime>;
 type AccountId = H160;
+type Balance = u128;
 
 // Configure a mock runtime to test the pallet.
 construct_runtime!(
@@ -30,50 +29,25 @@ construct_runtime!(
 	}
 );
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = pallet_balances::AccountData<u128>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ();
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type Nonce = u64;
-	type Block = Block;
+	type AccountData = pallet_balances::AccountData<Balance>;
 }
 
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
 }
 
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type Balance = u128;
-	type DustRemoval = ();
+	type Balance = Balance;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type ReserveIdentifier = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
 	type RuntimeHoldReason = ();
+	type DustRemoval = ();
 }
 
 parameter_types! {

--- a/runtime/laos/src/tests/xcm_mock/parachain.rs
+++ b/runtime/laos/src/tests/xcm_mock/parachain.rs
@@ -32,9 +32,7 @@ use polkadot_parachain_primitives::primitives::Sibling;
 use sp_core::{ConstU128, ConstU32, H160, U256};
 use sp_io::storage;
 use sp_runtime::{
-	traits::{
-		AccountIdConversion, Convert, IdentityLookup, MaybeEquivalence, TryConvert,
-	},
+	traits::{AccountIdConversion, Convert, IdentityLookup, MaybeEquivalence, TryConvert},
 	ConsensusEngineId,
 };
 use sp_std::{boxed::Box, prelude::*, str::FromStr};

--- a/runtime/laos/src/tests/xcm_mock/parachain.rs
+++ b/runtime/laos/src/tests/xcm_mock/parachain.rs
@@ -9,8 +9,8 @@ use cumulus_primitives_core::{
 	MultiAsset, MultiLocation, NetworkId, Plurality, XcmContext, XcmError,
 };
 use frame_support::{
-	construct_runtime, match_types, parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU64, Everything, FindAuthor, Nothing, OriginTrait},
+	construct_runtime, derive_impl, match_types, parameter_types,
+	traits::{AsEnsureOriginWithArg, Everything, FindAuthor, Nothing, OriginTrait},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 	PalletId,
 };
@@ -29,11 +29,11 @@ use orml_traits::{
 use pallet_xcm::XcmPassthrough;
 use parity_scale_codec::Encode;
 use polkadot_parachain_primitives::primitives::Sibling;
-use sp_core::{ConstU128, ConstU32, H160, H256, U256};
+use sp_core::{ConstU128, ConstU32, H160, U256};
 use sp_io::storage;
 use sp_runtime::{
 	traits::{
-		AccountIdConversion, BlakeTwo256, Convert, IdentityLookup, MaybeEquivalence, TryConvert,
+		AccountIdConversion, Convert, IdentityLookup, MaybeEquivalence, TryConvert,
 	},
 	ConsensusEngineId,
 };
@@ -76,50 +76,26 @@ construct_runtime!(
 	}
 );
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<Balance>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ();
-	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type Nonce = u64;
-	type Block = Block;
+	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Runtime>;
 }
 
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 0;
 }
 
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
 	type Balance = Balance;
-	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type ReserveIdentifier = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
 	type RuntimeHoldReason = ();
+	type DustRemoval = ();
 }
 
 parameter_types! {

--- a/runtime/laos/src/tests/xcm_mock/relay_chain.rs
+++ b/runtime/laos/src/tests/xcm_mock/relay_chain.rs
@@ -1,12 +1,11 @@
 //! Mock Kusama relay chain runtime.
 
 use frame_support::{
-	construct_runtime, parameter_types,
+	construct_runtime, derive_impl, parameter_types,
 	traits::{ConstU32, Everything, Nothing, ProcessMessage, ProcessMessageError},
 	weights::{Weight, WeightMeter},
 };
 use frame_system::EnsureRoot;
-use sp_core::H256;
 use sp_runtime::{traits::IdentityLookup, AccountId32};
 
 use polkadot_parachain_primitives::primitives::Id as ParaId;
@@ -43,30 +42,12 @@ parameter_types! {
 }
 pub type Block = frame_system::mocking::MockBlock<Runtime>;
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
-	type Hash = H256;
-	type Hashing = ::sp_runtime::traits::BlakeTwo256;
+	type Block = Block;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = BlockHashCount;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type Version = ();
-	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<Balance>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type DbWeight = ();
-	type BaseCallFilter = Everything;
-	type SystemWeightInfo = ();
-	type SS58Prefix = ();
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type Block = Block;
 }
 
 parameter_types! {
@@ -75,20 +56,15 @@ parameter_types! {
 	pub const MaxReserves: u32 = 50;
 }
 
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
 	type Balance = Balance;
-	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type ReserveIdentifier = ();
-	type FreezeIdentifier = ();
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type MaxHolds = ();
-	type MaxFreezes = ();
 	type RuntimeHoldReason = ();
+	type DustRemoval = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = MaxReserves;
 }
 
 impl shared::Config for Runtime {}

--- a/runtime/laos/src/types/to_author.rs
+++ b/runtime/laos/src/types/to_author.rs
@@ -53,21 +53,15 @@ mod tests {
 		pub const ExistentialDeposit: u128 = 1;
 	}
 
+	#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 	impl pallet_balances::Config for Test {
-		type MaxReserves = ();
-		type ReserveIdentifier = [u8; 4];
-		type MaxLocks = ();
 		type Balance = Balance;
-		type RuntimeEvent = RuntimeEvent;
-		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
-		type WeightInfo = ();
 		type RuntimeHoldReason = ();
-		type FreezeIdentifier = ();
-		type MaxHolds = ();
-		type MaxFreezes = ();
+		type DustRemoval = ();
 	}
+
 	impl pallet_authorship::Config for Test {
 		type FindAuthor = AuthorGiven;
 		type EventHandler = ();


### PR DESCRIPTION
- affects only `mock` runtimes
- uses `derive_impl` and `TestDefaultConfig` to reduce repeated code