### PR TITLE
Enhance Clippy Linting Rules in CI Pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           rustup component add clippy
       - name: Check clippy
         run: |
-          cargo clippy --all-targets --workspace --features runtime-benchmarks --features try-runtime
+          cargo clippy --release --all --tests --features runtime-benchmarks,try-runtime -- -D warnings
   test:
     runs-on:
       group: laos

--- a/pallets/asset-metadata-extender/src/tests.rs
+++ b/pallets/asset-metadata-extender/src/tests.rs
@@ -153,7 +153,7 @@ fn update_extension_works() {
 		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
 		assert_eq!(
 			AssetMetadataExtender::token_uris_by_claimer_and_location(
-				claimer.clone(),
+				claimer,
 				universal_location.clone()
 			)
 			.unwrap(),
@@ -161,13 +161,13 @@ fn update_extension_works() {
 		);
 
 		assert_ok!(AssetMetadataExtender::update_token_uri_extension(
-			claimer.clone(),
+			claimer,
 			universal_location.clone(),
 			new_token_uri.clone()
 		));
 		assert_eq!(
 			AssetMetadataExtender::token_uris_by_claimer_and_location(
-				claimer.clone(),
+				claimer,
 				universal_location.clone()
 			)
 			.unwrap(),
@@ -186,10 +186,10 @@ fn after_update_extension_it_returns_the_new_value() {
 		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 		let new_token_uri: TokenUriOf<Test> = bounded_vec![3; 10];
 
-		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
+		create_token_uri_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
 			AssetMetadataExtender::token_uris_by_claimer_and_location(
-				claimer.clone(),
+				claimer,
 				universal_location.clone()
 			)
 			.unwrap(),
@@ -203,7 +203,7 @@ fn after_update_extension_it_returns_the_new_value() {
 		));
 		assert_eq!(
 			AssetMetadataExtender::token_uris_by_claimer_and_location(
-				claimer.clone(),
+				claimer,
 				universal_location.clone()
 			)
 			.unwrap(),
@@ -244,10 +244,10 @@ fn after_update_extension_counter_does_not_increase() {
 		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 		let new_token_uri: TokenUriOf<Test> = bounded_vec![3; 10];
 
-		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
+		create_token_uri_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(AssetMetadataExtender::extensions_counter(universal_location.clone()), 1);
 		assert_ok!(AssetMetadataExtender::update_token_uri_extension(
-			claimer.clone(),
+			claimer,
 			universal_location.clone(),
 			new_token_uri.clone()
 		));
@@ -309,7 +309,7 @@ fn token_uri_extension_by_index_works() {
 		for i in 0..n {
 			let claimer = H160::from_low_u64_be(i as u64);
 			create_token_uri_extension(
-				claimer.clone(),
+				claimer,
 				universal_location.clone(),
 				token_uri_expected.clone(),
 			);
@@ -346,11 +346,11 @@ fn get_extension_by_location_and_claimer_works() {
 		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
 		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
-		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
+		create_token_uri_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert_eq!(
 			AssetMetadataExtender::extension_by_location_and_claimer(
 				universal_location.clone(),
-				claimer.clone()
+				claimer
 			)
 			.unwrap(),
 			token_uri
@@ -365,7 +365,7 @@ fn has_extension_should_return_true_if_it_exists() {
 		let universal_location: UniversalLocationOf<Test> = bounded_vec![1; 10];
 		let token_uri: TokenUriOf<Test> = bounded_vec![2; 10];
 
-		create_token_uri_extension(claimer.clone(), universal_location.clone(), token_uri.clone());
+		create_token_uri_extension(claimer, universal_location.clone(), token_uri.clone());
 		assert!(AssetMetadataExtender::has_extension(universal_location, claimer));
 	});
 }

--- a/pallets/laos-evolution/src/benchmarking.rs
+++ b/pallets/laos-evolution/src/benchmarking.rs
@@ -98,7 +98,7 @@ mod benchmarks {
 		let caller: T::AccountId = whitelisted_caller();
 		let owner = caller.clone();
 		let collection_id = LaosEvolution::<T>::create_collection(owner.clone()).unwrap();
-		let _ = LaosEvolution::<T>::enable_public_minting(owner.clone(), collection_id).unwrap();
+		LaosEvolution::<T>::enable_public_minting(owner.clone(), collection_id).unwrap();
 
 		#[block]
 		{

--- a/pallets/laos-evolution/src/tests.rs
+++ b/pallets/laos-evolution/src/tests.rs
@@ -531,7 +531,7 @@ fn disable_public_minting_for_nonexistent_collection_fails() {
 #[test]
 fn is_public_minting_enabled_for_nonexistent_returns_false() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(LaosEvolution::is_public_minting_enabled(0), false);
+		assert!(!LaosEvolution::is_public_minting_enabled(0));
 	});
 }
 
@@ -540,11 +540,11 @@ fn is_public_minting_enabled_returns_updated_value() {
 	new_test_ext().execute_with(|| {
 		let collection_id = create_collection(ALICE);
 		let who = AccountId::from_str(ALICE).unwrap();
-		assert_eq!(LaosEvolution::is_public_minting_enabled(collection_id), false);
+		assert!(!LaosEvolution::is_public_minting_enabled(collection_id));
 		assert_ok!(LaosEvolution::enable_public_minting(who, collection_id));
-		assert_eq!(LaosEvolution::is_public_minting_enabled(collection_id), true);
+		assert!(LaosEvolution::is_public_minting_enabled(collection_id));
 		assert_ok!(LaosEvolution::disable_public_minting(who, collection_id));
-		assert_eq!(LaosEvolution::is_public_minting_enabled(collection_id), false);
+		assert!(!LaosEvolution::is_public_minting_enabled(collection_id));
 	});
 }
 

--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -78,7 +78,7 @@ where
 	/// Retrieves the auto-compounding value for a delegation. The `delegations_config` must be a
 	/// sorted vector for binary_search to work.
 	pub fn get_for_delegator(&self, delegator: &T::AccountId) -> Option<Percent> {
-		match self.0.binary_search_by(|d| d.delegator.cmp(&delegator)) {
+		match self.0.binary_search_by(|d| d.delegator.cmp(delegator)) {
 			Ok(index) => Some(self.0[index].value),
 			Err(_) => None,
 		}
@@ -112,7 +112,7 @@ where
 	/// Returns `true` if the entry was removed, `false` otherwise. The `delegations_config` must be
 	/// a sorted vector for binary_search to work.
 	pub fn remove_for_delegator(&mut self, delegator: &T::AccountId) -> bool {
-		match self.0.binary_search_by(|d| d.delegator.cmp(&delegator)) {
+		match self.0.binary_search_by(|d| d.delegator.cmp(delegator)) {
 			Ok(index) => {
 				self.0.remove(index);
 				true
@@ -219,7 +219,7 @@ where
 		// set auto-compound config if the percent is non-zero
 		if !auto_compound.is_zero() {
 			let mut auto_compounding_state = Self::get_storage(&candidate);
-			auto_compounding_state.set_for_delegator(delegator.clone(), auto_compound.clone())?;
+			auto_compounding_state.set_for_delegator(delegator.clone(), auto_compound)?;
 			auto_compounding_state.set_storage(&candidate);
 		}
 
@@ -280,16 +280,14 @@ where
 	pub(crate) fn remove_auto_compound(candidate: &T::AccountId, delegator: &T::AccountId) {
 		let mut auto_compounding_state = Self::get_storage(candidate);
 		if auto_compounding_state.remove_for_delegator(delegator) {
-			auto_compounding_state.set_storage(&candidate);
+			auto_compounding_state.set_storage(candidate);
 		}
 	}
 
 	/// Returns the value of auto-compound, if it exists for a given delegation, zero otherwise.
 	pub(crate) fn auto_compound(candidate: &T::AccountId, delegator: &T::AccountId) -> Percent {
 		let delegations_config = Self::get_storage(candidate);
-		delegations_config
-			.get_for_delegator(&delegator)
-			.unwrap_or_else(|| Percent::zero())
+		delegations_config.get_for_delegator(delegator).unwrap_or_else(Percent::zero)
 	}
 }
 

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -780,7 +780,7 @@ benchmarks! {
 		} else {
 			0u32.into()
 		};
-		let (caller, _) = create_funded_user::<T>("caller", USER_SEED, extra.into());
+		let (caller, _) = create_funded_user::<T>("caller", USER_SEED, extra);
 		// Delegation count
 		let mut del_del_count = 0u32;
 		// Nominate MaxDelegationsPerDelegators collator candidates
@@ -1519,7 +1519,7 @@ benchmarks! {
 		assert!(
 			!Pallet::<T>::delegation_scheduled_requests(&collator)
 				.iter()
-				.any(|x| &x.delegator == &delegator)
+				.any(|x| x.delegator == delegator)
 		);
 	}
 
@@ -1560,7 +1560,7 @@ benchmarks! {
 			ideal: Perbill::one(),
 			max: Perbill::one(),
 		};
-		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation.clone())?;
+		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation)?;
 		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 101u32)?;
 		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 100u32)?;
 
@@ -1606,7 +1606,7 @@ benchmarks! {
 			ideal: Perbill::one(),
 			max: Perbill::one(),
 		};
-		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation.clone())?;
+		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation)?;
 		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 101u32)?;
 		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 100u32)?;
 
@@ -1730,7 +1730,7 @@ benchmarks! {
 		{
 			<Pallet<T>>::mint_and_compound(
 				100u32.into(),
-				auto_compound.clone(),
+				*auto_compound,
 				prime_candidate.clone(),
 				owner.clone(),
 			);
@@ -1744,7 +1744,7 @@ benchmarks! {
 		} in &delegations
 		{
 			assert!(
-				T::Currency::free_balance(&owner) > initial_delegator_balance,
+				T::Currency::free_balance(owner) > initial_delegator_balance,
 				"delegator should have been paid in pay_one_collator_reward"
 			);
 		}
@@ -1795,7 +1795,7 @@ benchmarks! {
 		// directly and then call pay_one_collator_reward directly.
 
 		let round_for_payout = 5;
-		<DelayedPayouts<T>>::insert(&round_for_payout, DelayedPayout {
+		<DelayedPayouts<T>>::insert(round_for_payout, DelayedPayout {
 			// NOTE: round_issuance is not correct here, but it doesn't seem to cause problems
 			round_issuance: 1000u32.into(),
 			total_staking_reward: total_staked,
@@ -1837,7 +1837,7 @@ benchmarks! {
 		// nominators should have been paid
 		for delegator in &delegators {
 			assert!(
-				T::Currency::free_balance(&delegator) > initial_stake_amount,
+				T::Currency::free_balance(delegator) > initial_stake_amount,
 				"delegator should have been paid in pay_one_collator_reward"
 			);
 		}
@@ -2209,7 +2209,7 @@ benchmarks! {
 		)?;
 		let original_free_balance = T::Currency::free_balance(&collator);
 	}: {
-		Pallet::<T>::mint_collator_reward(1u32.into(), collator.clone(), 50u32.into())
+		Pallet::<T>::mint_collator_reward(1u32, collator.clone(), 50u32.into())
 	}
 	verify {
 		assert_eq!(T::Currency::free_balance(&collator), original_free_balance + 50u32.into());
@@ -2226,7 +2226,7 @@ benchmarks! {
 		)?;
 		let original_free_balance = T::Currency::free_balance(&collator);
 	}: {
-		Pallet::<T>::send_collator_rewards(1u32.into(), collator.clone(), 50u32.into())
+		Pallet::<T>::send_collator_rewards(1u32, collator.clone(), 50u32.into())
 	}
 	verify {
 		assert_eq!(T::Currency::free_balance(&collator), original_free_balance + 50u32.into());

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -154,7 +154,7 @@ impl<T: Config> Pallet<T> {
 				error: <Error<T>>::DelegatorBondBelowMin.into(),
 			},
 		);
-		let new_amount: BalanceOf<T> = (bonded_amount - decrease_amount).into();
+		let new_amount: BalanceOf<T> = bonded_amount - decrease_amount;
 		ensure!(
 			new_amount >= T::MinDelegation::get(),
 			DispatchErrorWithPostInfo {
@@ -166,7 +166,7 @@ impl<T: Config> Pallet<T> {
 		// Net Total is total after pending orders are executed
 		let net_total = state.total().saturating_sub(state.less_total);
 		// Net Total is always >= MinDelegation
-		let max_subtracted_amount = net_total.saturating_sub(T::MinDelegation::get().into());
+		let max_subtracted_amount = net_total.saturating_sub(T::MinDelegation::get());
 		ensure!(
 			decrease_amount <= max_subtracted_amount,
 			DispatchErrorWithPostInfo {
@@ -269,7 +269,7 @@ impl<T: Config> Pallet<T> {
 					true
 				} else {
 					ensure!(
-						state.total().saturating_sub(T::MinDelegation::get().into()) >= amount,
+						state.total().saturating_sub(T::MinDelegation::get()) >= amount,
 						DispatchErrorWithPostInfo {
 							post_info: Some(actual_weight).into(),
 							error: <Error<T>>::DelegatorBondBelowMin.into(),
@@ -323,7 +323,7 @@ impl<T: Config> Pallet<T> {
 				for bond in &mut state.delegations.0 {
 					if bond.owner == collator {
 						return if bond.amount > amount {
-							let amount_before: BalanceOf<T> = bond.amount.into();
+							let amount_before: BalanceOf<T> = bond.amount;
 							bond.amount = bond.amount.saturating_sub(amount);
 							let mut collator_info = <CandidateInfo<T>>::get(&collator)
 								.ok_or(<Error<T>>::CandidateDNE)
@@ -334,7 +334,7 @@ impl<T: Config> Pallet<T> {
 
 							state
 								.total_sub_if::<T, _>(amount, |total| {
-									let new_total: BalanceOf<T> = total.into();
+									let new_total: BalanceOf<T> = total;
 									ensure!(
 										new_total >= T::MinDelegation::get(),
 										<Error<T>>::DelegationBelowMin

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1234,7 +1234,7 @@ pub mod pallet {
 			let (in_top, weight) = Self::delegation_bond_more_without_event(
 				delegator.clone(),
 				candidate.clone(),
-				more.clone(),
+				more,
 			)?;
 			Pallet::<T>::deposit_event(Event::DelegationIncreased {
 				delegator,
@@ -1321,11 +1321,11 @@ pub mod pallet {
 			ensure!(candidates.len() < 100, <Error<T>>::InsufficientBalance);
 			for candidate in &candidates {
 				ensure!(
-					<CandidateInfo<T>>::get(&candidate).is_none(),
+					<CandidateInfo<T>>::get(candidate).is_none(),
 					<Error<T>>::CandidateNotLeaving
 				);
 				ensure!(
-					<DelegationScheduledRequests<T>>::get(&candidate).is_empty(),
+					<DelegationScheduledRequests<T>>::get(candidate).is_empty(),
 					<Error<T>>::CandidateNotLeaving
 				);
 			}
@@ -1334,7 +1334,7 @@ pub mod pallet {
 				<DelegationScheduledRequests<T>>::remove(candidate);
 			}
 
-			Ok(().into())
+			Ok(())
 		}
 
 		/// Notify a collator is inactive during MaxOfflineRounds
@@ -1401,7 +1401,7 @@ pub mod pallet {
 				return Err(<Error<T>>::CannotBeNotifiedAsInactive.into());
 			}
 
-			Ok(().into())
+			Ok(())
 		}
 
 		/// Enable/Disable marking offline feature
@@ -1445,9 +1445,9 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		pub fn set_candidate_bond_to_zero(acc: &T::AccountId) -> Weight {
 			let actual_weight = T::WeightInfo::set_candidate_bond_to_zero(T::MaxCandidates::get());
-			if let Some(mut state) = <CandidateInfo<T>>::get(&acc) {
+			if let Some(mut state) = <CandidateInfo<T>>::get(acc) {
 				state.bond_less::<T>(acc.clone(), state.bond);
-				<CandidateInfo<T>>::insert(&acc, state);
+				<CandidateInfo<T>>::insert(acc, state);
 			}
 			actual_weight
 		}
@@ -1911,7 +1911,7 @@ pub mod pallet {
 							num_paid_delegations += 1u32;
 							Self::mint_and_compound(
 								due,
-								auto_compound.clone(),
+								auto_compound,
 								collator.clone(),
 								owner.clone(),
 							);
@@ -2023,10 +2023,10 @@ pub mod pallet {
 				delegation_count = delegation_count.saturating_add(state.delegation_count);
 				total = total.saturating_add(state.total_counted);
 				let CountedDelegations { uncounted_stake, rewardable_delegations } =
-					Self::get_rewardable_delegators(&account);
+					Self::get_rewardable_delegators(account);
 				let total_counted = state.total_counted.saturating_sub(uncounted_stake);
 
-				let auto_compounding_delegations = <AutoCompoundingDelegations<T>>::get(&account)
+				let auto_compounding_delegations = <AutoCompoundingDelegations<T>>::get(account)
 					.into_iter()
 					.map(|x| (x.delegator, x.value))
 					.collect::<BTreeMap<_, _>>();
@@ -2038,7 +2038,7 @@ pub mod pallet {
 						auto_compound: auto_compounding_delegations
 							.get(&d.owner)
 							.cloned()
-							.unwrap_or_else(|| Percent::zero()),
+							.unwrap_or_else(Percent::zero),
 					})
 					.collect();
 
@@ -2153,7 +2153,7 @@ pub mod pallet {
 			candidate: T::AccountId,
 			delegator: T::AccountId,
 		) {
-			if let Ok(amount_transferred) = T::PayoutReward::payout(&delegator, amt.clone()) {
+			if let Ok(amount_transferred) = T::PayoutReward::payout(&delegator, amt) {
 				Self::deposit_event(Event::Rewarded {
 					account: delegator.clone(),
 					rewards: amount_transferred,
@@ -2167,7 +2167,7 @@ pub mod pallet {
 				if let Err(err) = Self::delegation_bond_more_without_event(
 					delegator.clone(),
 					candidate.clone(),
-					compound_amount.clone(),
+					compound_amount,
 				) {
 					log::debug!(
 						"skipped compounding staking reward towards candidate '{:?}' for delegator '{:?}': {:?}",
@@ -2181,7 +2181,7 @@ pub mod pallet {
 				Pallet::<T>::deposit_event(Event::Compounded {
 					delegator,
 					candidate,
-					amount: compound_amount.clone(),
+					amount: compound_amount,
 				});
 			};
 		}

--- a/pallets/parachain-staking/src/rewards/transfer_from_rewards_account.rs
+++ b/pallets/parachain-staking/src/rewards/transfer_from_rewards_account.rs
@@ -44,7 +44,7 @@ impl<Runtime: crate::Config> PayoutReward<Runtime> for TransferFromRewardsAccoun
 		// for clearer error handling.
 		match Runtime::Currency::transfer(
 			&rewards_account,
-			&delegator_id,
+			delegator_id,
 			amount,
 			ExistenceRequirement::KeepAlive,
 		) {
@@ -88,7 +88,7 @@ impl<T: Config> Pallet<T> {
 			Self::deposit_event(Event::Rewarded { account: collator_id, rewards: amount });
 		}
 
-		return T::WeightInfo::send_collator_rewards();
+		T::WeightInfo::send_collator_rewards()
 	}
 }
 

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -498,7 +498,7 @@ impl<
 	{
 		let request = self.request.ok_or(Error::<T>::PendingCandidateRequestsDNE)?;
 		let event = Event::CancelledCandidateBondLess {
-			candidate: who.clone().into(),
+			candidate: who.clone(),
 			amount: request.amount.into(),
 			execute_round: request.when_executable,
 		};
@@ -614,7 +614,7 @@ impl<
 			// only increment delegation count if we are not kicking a bottom delegation
 			self.delegation_count = self.delegation_count.saturating_add(1u32);
 		}
-		<TopDelegations<T>>::insert(&candidate, top_delegations);
+		<TopDelegations<T>>::insert(candidate, top_delegations);
 		less_total_staked
 	}
 	/// Add delegation to bottom delegations
@@ -653,12 +653,12 @@ impl<
 			let leaving = delegator_state.delegations.0.len() == 1usize;
 			delegator_state.rm_delegation::<T>(candidate);
 			<Pallet<T>>::delegation_remove_request_with_state(
-				&candidate,
+				candidate,
 				&lowest_bottom_to_be_kicked.owner,
 				&mut delegator_state,
 			);
 			<AutoCompoundDelegations<T>>::remove_auto_compound(
-				&candidate,
+				candidate,
 				&lowest_bottom_to_be_kicked.owner,
 			);
 

--- a/precompile/asset-metadata-extender/src/tests.rs
+++ b/precompile/asset-metadata-extender/src/tests.rs
@@ -515,12 +515,12 @@ fn extension_by_location_and_claimer_works() {
 			.build();
 
 		precompiles()
-			.prepare_test(claimer.clone(), H160(PRECOMPILE_ADDRESS), input.clone())
+			.prepare_test(claimer, H160(PRECOMPILE_ADDRESS), input.clone())
 			.execute_returns_raw(sp_std::vec![]);
 
 		let input = EvmDataWriter::new_with_selector(Action::ExtensionOfULByClaimer)
 			.write(universal_location.clone())
-			.write(Address::from(claimer.clone()))
+			.write(Address::from(claimer))
 			.build();
 
 		precompiles()
@@ -537,7 +537,7 @@ fn extension_by_location_and_claimer_of_unexistent_claim_reverts() {
 
 		let input = EvmDataWriter::new_with_selector(Action::ExtensionOfULByClaimer)
 			.write(universal_location.clone())
-			.write(Address::from(claimer.clone()))
+			.write(Address::from(claimer))
 			.build();
 
 		precompiles()
@@ -559,12 +559,12 @@ fn has_extension_by_claim_of_existent_claim_returns_true() {
 			.build();
 
 		precompiles()
-			.prepare_test(claimer.clone(), H160(PRECOMPILE_ADDRESS), input.clone())
+			.prepare_test(claimer, H160(PRECOMPILE_ADDRESS), input.clone())
 			.execute_returns_raw(sp_std::vec![]);
 
 		let input = EvmDataWriter::new_with_selector(Action::HasExtension)
 			.write(universal_location.clone())
-			.write(Address::from(claimer.clone()))
+			.write(Address::from(claimer))
 			.build();
 
 		precompiles()
@@ -581,7 +581,7 @@ fn has_extension_by_claimer_of_unexistent_claim_returns_false() {
 
 		let input = EvmDataWriter::new_with_selector(Action::HasExtension)
 			.write(universal_location.clone())
-			.write(Address::from(claimer.clone()))
+			.write(Address::from(claimer))
 			.build();
 
 		precompiles()

--- a/precompile/evolution-collection-factory/src/lib.rs
+++ b/precompile/evolution-collection-factory/src/lib.rs
@@ -90,9 +90,7 @@ where
 							.log2(
 								SELECTOR_LOG_NEW_COLLECTION,
 								owner,
-								EvmDataWriter::new()
-									.write(Address(collection_address.into()))
-									.build(),
+								EvmDataWriter::new().write(Address(collection_address)).build(),
 							)
 							.record(handle)?;
 
@@ -103,9 +101,7 @@ where
 						// TODO: Add `ref_time` when precompiles are benchmarked
 						handle.record_external_cost(None, Some(consumed_weight.proof_size()))?;
 
-						Ok(succeed(
-							EvmDataWriter::new().write(Address(collection_address.into())).build(),
-						))
+						Ok(succeed(EvmDataWriter::new().write(Address(collection_address)).build()))
 					},
 					Err(err) => Err(revert_dispatch_error(err)),
 				}

--- a/precompile/evolution-collection-factory/src/mock.rs
+++ b/precompile/evolution-collection-factory/src/mock.rs
@@ -143,7 +143,7 @@ where
 	}
 
 	fn is_precompile(&self, _address: H160, _gas: u64) -> fp_evm::IsPrecompileResult {
-		return fp_evm::IsPrecompileResult::Answer { is_precompile: true, extra_cost: 0 }
+		fp_evm::IsPrecompileResult::Answer { is_precompile: true, extra_cost: 0 }
 	}
 }
 

--- a/precompile/evolution-collection-factory/src/tests.rs
+++ b/precompile/evolution-collection-factory/src/tests.rs
@@ -115,7 +115,7 @@ fn create_collection_assign_collection_to_caller() {
 			.prepare_test(H160([1u8; 20]), H160(PRECOMPILE_ADDRESS), input)
 			.execute_returns(expected_output);
 
-		assert_eq!(LaosEvolution::<Test>::collection_owner(0), Some(H160([1u8; 20].into())));
+		assert_eq!(LaosEvolution::<Test>::collection_owner(0), Some(H160([1u8; 20])));
 	});
 }
 
@@ -138,10 +138,10 @@ fn create_collection_inserts_bytecode_to_address() {
 
 		let collection_address = &H160::from_str(expected_address).unwrap();
 		// Address is not empty
-		assert!(!Evm::<Test>::is_account_empty(&collection_address));
+		assert!(!Evm::<Test>::is_account_empty(collection_address));
 
 		// Address has correct code
-		assert!(AccountCodes::<Test>::get(&collection_address) == REVERT_BYTECODE);
+		assert!(AccountCodes::<Test>::get(collection_address) == REVERT_BYTECODE);
 	});
 }
 

--- a/precompile/evolution-collection/src/mock.rs
+++ b/precompile/evolution-collection/src/mock.rs
@@ -150,7 +150,7 @@ where
 				Some(MockEvolutionCollectionPrecompile::execute(handle)),
 			H160(EVOLUTION_FACTORY_PRECOMPILE_ADDRESS) =>
 				Some(MockEvolutionCollectionFactoryPrecompile::execute(handle)),
-			_ => return None,
+			_ => None,
 		}
 	}
 

--- a/precompile/evolution-collection/src/tests.rs
+++ b/precompile/evolution-collection/src/tests.rs
@@ -31,7 +31,7 @@ fn precompiles() -> MockPrecompileSet<Test> {
 fn create_collection(owner: impl Into<H160>) -> H160 {
 	let owner: H160 = owner.into();
 	let input = EvmDataWriter::new_with_selector(CollectionFactoryAction::CreateCollection)
-		.write(Address(owner.clone()))
+		.write(Address(owner))
 		.build();
 
 	let mut handle = MockHandle::new(
@@ -47,7 +47,7 @@ fn create_collection(owner: impl Into<H160>) -> H160 {
 
 	let res = precompiles().execute(&mut handle).unwrap().unwrap();
 
-	H160::from_slice(&res.output.as_slice()[12..].as_ref())
+	H160::from_slice(res.output.as_slice()[12..].as_ref())
 }
 
 /// Utility function to mint a token with external token uri
@@ -63,7 +63,7 @@ fn mint(
 ) -> TokenId {
 	let owner: H160 = owner.into();
 	let input = EvmDataWriter::new_with_selector(Action::Mint)
-		.write(Address(owner.clone()))
+		.write(Address(owner))
 		.write(U256::from(slot))
 		.write(Bytes(token_uri))
 		.build();
@@ -144,7 +144,7 @@ fn mint_should_generate_log() {
 #[test]
 fn unexistent_selector_should_revert() {
 	new_test_ext().execute_with(|| {
-		let input = EvmDataWriter::new_with_selector(0x12345678 as u32).build();
+		let input = EvmDataWriter::new_with_selector(0x12345678_u32).build();
 
 		precompiles()
 			.prepare_test(H160([1u8; 20]), H160(EVOLUTION_FACTORY_PRECOMPILE_ADDRESS), input)

--- a/runtime/klaos/src/tests/mod.rs
+++ b/runtime/klaos/src/tests/mod.rs
@@ -123,11 +123,7 @@ fn account_vests_correctly_over_time() {
 		assert!(vesting_info.is_valid());
 
 		// Transfer vested funds from Alice to Bob
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(alice),
-			bob.clone(),
-			vesting_info
-		));
+		assert_ok!(Vesting::vested_transfer(RuntimeOrigin::signed(alice), bob, vesting_info));
 
 		assert_eq!(Balances::total_balance(&alice), 0);
 		assert_eq!(Balances::total_balance(&bob), total_vested_amount);
@@ -136,12 +132,12 @@ fn account_vests_correctly_over_time() {
 		// Simulate block progression and check Bob's balance each block
 		for block_num in cliff_duration..=cliff_duration + vesting_duration as u32 {
 			frame_system::Pallet::<Runtime>::set_block_number(block_num);
-			assert_ok!(Vesting::vest(RuntimeOrigin::signed(bob.clone())));
+			assert_ok!(Vesting::vest(RuntimeOrigin::signed(bob)));
 			let vested_amount = (block_num - cliff_duration) as u128 * amount_vested_per_block;
-			assert_eq!(Balances::usable_balance(&bob), vested_amount);
+			assert_eq!(Balances::usable_balance(bob), vested_amount);
 		}
 
 		// Check that Bob's balance is now the total vested amount
-		assert_eq!(Balances::usable_balance(&bob), total_vested_amount);
+		assert_eq!(Balances::usable_balance(bob), total_vested_amount);
 	});
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the GitHub Actions CI pipeline to enforce stricter linting rules with Clippy. This includes checking all targets, including tests, in release mode, and treating all warnings as errors.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Make Clippy Checks More Restrictive in CI Pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build.yml
<li>Updated the clippy command to be more restrictive by using <code>--release </code><br><code>--all --tests</code> flags and specifying <code>-D warnings</code> to deny warnings.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/526/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

