### PR TITLE
Refactor Session Configuration in Laos Runtime for Enhanced Clarity and Efficiency

### DIFF
--- a/runtime/laos/src/configs/session.rs
+++ b/runtime/laos/src/configs/session.rs
@@ -1,15 +1,17 @@
-use crate::{configs, ConvertInto, Runtime, RuntimeEvent, SessionKeys};
+use crate::{
+	configs::parachain_staking::ParachainStakingAdapter, AccountId, Runtime, RuntimeEvent,
+	SessionKeys,
+};
+use sp_runtime::traits::{ConvertInto, OpaqueKeys};
 
 impl pallet_session::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type ValidatorId = <Self as frame_system::Config>::AccountId;
-	// we don't have stash and controller, thus we don't need the convert as well.
+	type ValidatorId = AccountId;
 	type ValidatorIdOf = ConvertInto;
-	type ShouldEndSession = configs::parachain_staking::ParachainStakingAdapter;
-	type NextSessionRotation = configs::parachain_staking::ParachainStakingAdapter;
-	type SessionManager = configs::parachain_staking::ParachainStakingAdapter;
-	// Essentially just Aura, but let's be pedantic.
-	type SessionHandler = <SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
+	type ShouldEndSession = ParachainStakingAdapter;
+	type NextSessionRotation = ParachainStakingAdapter;
+	type SessionManager = ParachainStakingAdapter;
+	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
 	type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Refactored the session configuration in `runtime/laos/src/configs/session.rs` for improved clarity and efficiency.
- Simplified the `ValidatorId` type definition to directly use `AccountId`.
- Directly utilized `ParachainStakingAdapter` from `configs::parachain_staking`, streamlining the configuration.
- Enhanced readability by replacing `sp_runtime::traits::OpaqueKeys` with `OpaqueKeys` for the `SessionHandler` type.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session.rs</strong><dd><code>Refactor Session Configuration for Clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/session.rs
<li>Refactored imports for clarity and efficiency.<br> <li> Simplified <code>ValidatorId</code> type definition.<br> <li> Utilized <code>ParachainStakingAdapter</code> directly from <br><code>configs::parachain_staking</code>.<br> <li> Replaced <code>sp_runtime::traits::OpaqueKeys</code> with <code>OpaqueKeys</code> for <br><code>SessionHandler</code>.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/528/files#diff-825ca4e79dea43f764e310bd91ad62a7e61122b289e8b2c1aa75ed7254f637b5">+10/-8</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

