### PR TITLE
Refactor Parachain System Configuration and Cleanup Imports

### DIFF
--- a/runtime/laos/src/configs/cumulus_parachain_system.rs
+++ b/runtime/laos/src/configs/cumulus_parachain_system.rs
@@ -1,26 +1,23 @@
-use crate::{
-	Block, DmpQueue, InherentDataExt, RelayNumberStrictlyIncreases, Runtime, RuntimeEvent,
-	XcmpQueue,
-};
+use crate::{Block, DmpQueue, InherentDataExt, ParachainInfo, Runtime, RuntimeEvent, XcmpQueue};
 use frame_support::{parameter_types, weights::Weight};
 
 use laos_primitives::MAXIMUM_BLOCK_WEIGHT;
 
 parameter_types! {
-	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4); // TODO
-	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4); // TODO
+	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type OnSystemEvent = ();
-	type SelfParaId = parachain_info::Pallet<Runtime>;
+	type SelfParaId = ParachainInfo;
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type DmpMessageHandler = DmpQueue;
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 }
 
 struct CheckInherents;

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -13,7 +13,6 @@ pub mod types;
 mod weights;
 
 use core::marker::PhantomData;
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 use frame_support::{
 	construct_runtime,
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Simplified parachain system configuration by cleaning up unused imports and clarifying parameter usage.
- Removed `TODO` comments, indicating a review and finalization of `ReservedXcmpWeight` and `ReservedDmpWeight` parameters.
- Updated `CheckAssociatedRelayNumber` to directly use the qualified name from `cumulus_pallet_parachain_system`, improving clarity.
- Removed an unused import from `lib.rs`, streamlining the codebase.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cumulus_parachain_system.rs</strong><dd><code>Refactor and Simplify Parachain System Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/cumulus_parachain_system.rs
<li>Removed unused imports and simplified the use of <code>ParachainInfo</code>.<br> <li> Removed <code>TODO</code> comments from <code>ReservedXcmpWeight</code> and <code>ReservedDmpWeight</code> <br>parameters.<br> <li> Updated <code>CheckAssociatedRelayNumber</code> to use <br><code>cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/529/files#diff-7c3123d213dd4de6d096ac5e3beddd348c6a7636f540c8d1960928576d269e81">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Cleanup Unused Imports in lib.rs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs
- Removed unused import of `RelayNumberStrictlyIncreases`.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/529/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

