### PR TITLE
Align `MaxHolds` and `MaxFreezes` Parameters with `MaxLocks` and `MaxReserves` in `pallet_balances` Configuration

### DIFF
--- a/runtime/laos/src/configs/balances.rs
+++ b/runtime/laos/src/configs/balances.rs
@@ -12,24 +12,20 @@ parameter_types! {
 	pub const ExistentialDeposit: Balance = 0;
 	pub const MaxLocks: u32 = 50;
 	pub const MaxReserves: u32 = 50;
-	pub const MaxHolds: u32 = 0;
-	pub const MaxFreezes: u32 = 1;
 }
 
 impl pallet_balances::Config for Runtime {
-	type MaxLocks = MaxLocks;
-	/// The type for recording an account's balance.
-	type Balance = Balance;
-	/// The ubiquitous event type.
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = ();
+	type FreezeIdentifier = RuntimeFreezeReason;
+	type Balance = Balance;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type MaxReserves = MaxReserves;
 	type ReserveIdentifier = [u8; 8];
-	type FreezeIdentifier = RuntimeFreezeReason;
-	type MaxHolds = MaxHolds;
-	type RuntimeHoldReason = ();
-	type MaxFreezes = MaxFreezes;
+	type MaxHolds = MaxLocks;
+	type MaxFreezes = MaxReserves;
+	type MaxLocks = MaxLocks;
+	type MaxReserves = MaxReserves;
 	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/laos/src/configs/balances.rs
+++ b/runtime/laos/src/configs/balances.rs
@@ -15,17 +15,17 @@ parameter_types! {
 }
 
 impl pallet_balances::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeHoldReason = ();
-	type FreezeIdentifier = RuntimeFreezeReason;
+	type MaxLocks = MaxLocks;
 	type Balance = Balance;
+	type RuntimeHoldReason = ();
+	type RuntimeEvent = RuntimeEvent;
+	type FreezeIdentifier = RuntimeFreezeReason;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type ReserveIdentifier = [u8; 8];
 	type MaxHolds = MaxLocks;
 	type MaxFreezes = MaxReserves;
-	type MaxLocks = MaxLocks;
 	type MaxReserves = MaxReserves;
 	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/laos/src/configs/balances.rs
+++ b/runtime/laos/src/configs/balances.rs
@@ -19,13 +19,13 @@ impl pallet_balances::Config for Runtime {
 	type Balance = Balance;
 	type RuntimeHoldReason = ();
 	type RuntimeEvent = RuntimeEvent;
-	type FreezeIdentifier = RuntimeFreezeReason;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type MaxReserves = MaxReserves;
 	type ReserveIdentifier = [u8; 8];
+	type FreezeIdentifier = RuntimeFreezeReason;
 	type MaxHolds = MaxLocks;
 	type MaxFreezes = MaxReserves;
-	type MaxReserves = MaxReserves;
 	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/laos/src/configs/balances.rs
+++ b/runtime/laos/src/configs/balances.rs
@@ -17,7 +17,6 @@ parameter_types! {
 impl pallet_balances::Config for Runtime {
 	type MaxLocks = MaxLocks;
 	type Balance = Balance;
-	type RuntimeHoldReason = ();
 	type RuntimeEvent = RuntimeEvent;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
@@ -26,6 +25,7 @@ impl pallet_balances::Config for Runtime {
 	type ReserveIdentifier = [u8; 8];
 	type FreezeIdentifier = RuntimeFreezeReason;
 	type MaxHolds = MaxLocks;
+	type RuntimeHoldReason = ();
 	type MaxFreezes = MaxReserves;
 	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/laos/src/configs/balances.rs
+++ b/runtime/laos/src/configs/balances.rs
@@ -11,6 +11,8 @@ parameter_types! {
 	/// balance drops to a level that would trigger its deletion and subsequent nonce reset.
 	pub const ExistentialDeposit: Balance = 0;
 	pub const MaxLocks: u32 = 50;
+	pub const MaxFreezes: u32 = 50;
+	pub const MaxHolds: u32 = 50;
 	pub const MaxReserves: u32 = 50;
 }
 
@@ -24,8 +26,8 @@ impl pallet_balances::Config for Runtime {
 	type MaxReserves = MaxReserves;
 	type ReserveIdentifier = [u8; 8];
 	type FreezeIdentifier = RuntimeFreezeReason;
-	type MaxHolds = MaxLocks;
+	type MaxHolds = MaxHolds;
 	type RuntimeHoldReason = ();
-	type MaxFreezes = MaxReserves;
+	type MaxFreezes = MaxFreezes;
 	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed unused parameters `MaxHolds` and `MaxFreezes` from the `pallet_balances` configuration.
- Updated `MaxHolds` to use the same value as `MaxLocks`, aligning the holds limit with the locks limit.
- Updated `MaxFreezes` to use the same value as `MaxReserves`, aligning the freezes limit with the reserves limit.
- These changes simplify the configuration and ensure consistency across related parameters.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>balances.rs</strong><dd><code>Align `MaxHolds` and `MaxFreezes` with Other Parameters</code>&nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/balances.rs
<li>Removed <code>MaxHolds</code> and <code>MaxFreezes</code> parameters.<br> <li> Set <code>MaxHolds</code> to equal <code>MaxLocks</code>.<br> <li> Set <code>MaxFreezes</code> to equal <code>MaxReserves</code>.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/531/files#diff-c273ea519032c05d3509a3f28ccd2774398547ba43aae662dad536091c754b66">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

