### PR TITLE
Enhance EVM Configuration, Refactor Imports, and Add Tests

### DIFF
--- a/runtime/laos/src/apis.rs
+++ b/runtime/laos/src/apis.rs
@@ -1,5 +1,5 @@
 use fp_rpc::TransactionStatus;
-use frame_support::traits::Hooks;
+use frame_support::{traits::Hooks, weights::Weight};
 use pallet_ethereum::{Call::transact, Transaction as EthereumTransaction};
 use pallet_evm::{Account as EVMAccount, FeeCalculator, Runner};
 use sp_api::impl_runtime_apis;
@@ -16,7 +16,7 @@ use sp_version::RuntimeVersion;
 use super::{
 	AccountId, Aura, AuraId, Balance, Block, Ethereum, Executive, InherentDataExt, Nonce,
 	ParachainSystem, Runtime, RuntimeCall, SessionKeys, System, TransactionPayment,
-	UncheckedExtrinsic, Weight, EVM, VERSION,
+	UncheckedExtrinsic, EVM, VERSION,
 };
 
 /// TODO: hackish way to get the runtime version public. Waiting for substrate to expose it.

--- a/runtime/laos/src/configs/base_fee.rs
+++ b/runtime/laos/src/configs/base_fee.rs
@@ -1,5 +1,6 @@
-use crate::{Runtime, RuntimeEvent, U256};
+use crate::{Runtime, RuntimeEvent};
 use frame_support::parameter_types;
+use sp_core::U256;
 use sp_runtime::Permill;
 
 parameter_types! {

--- a/runtime/laos/src/configs/evm.rs
+++ b/runtime/laos/src/configs/evm.rs
@@ -76,6 +76,6 @@ mod tests {
 
 	#[test]
 	fn check_block_gas_limit() {
-			assert_eq!(BlockGasLimit::get(), 15000000.into());
+		assert_eq!(BlockGasLimit::get(), 15000000.into());
 	}
 }

--- a/runtime/laos/src/configs/evm.rs
+++ b/runtime/laos/src/configs/evm.rs
@@ -11,11 +11,11 @@ use laos_primitives::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO};
 /// Given the 500ms Weight, from which 75% only are used for transactions,
 /// the total EVM execution gas limit is: GAS_PER_SECOND * 0.500 * 0.75 ~= 15_000_000.
 /// Note: this value has been used in production by (and is copied from) the Moonbeam parachain.
-pub const GAS_PER_SECOND: u64 = 40_000_000;
+const GAS_PER_SECOND: u64 = 40_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
 /// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
+const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 

--- a/runtime/laos/src/configs/evm.rs
+++ b/runtime/laos/src/configs/evm.rs
@@ -1,10 +1,14 @@
 //! Pallets that enable EVM execution on Substrate
 use crate::{
 	precompiles::FrontierPrecompiles, types::ToAuthor, AccountId, Aura, Balances, BaseFee,
-	EVMChainId, Runtime, RuntimeEvent, Timestamp, Weight, U256, WEIGHT_REF_TIME_PER_SECOND,
+	EVMChainId, Runtime, RuntimeEvent, Timestamp,
 };
-use frame_support::parameter_types;
+use frame_support::{
+	parameter_types,
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+};
 use laos_primitives::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO};
+use sp_core::U256;
 
 /// Current approximation of the gas/s consumption considering
 /// EVM execution over compiled WASM (on 4.4Ghz CPU).

--- a/runtime/laos/src/configs/parachain_staking.rs
+++ b/runtime/laos/src/configs/parachain_staking.rs
@@ -1,8 +1,8 @@
 use crate::{
-	currency::UNIT, AccountId, Balances, BlockNumber, Permill, Runtime, RuntimeEvent, Vec, Weight,
+	currency::UNIT, AccountId, Balances, BlockNumber, Permill, Runtime, RuntimeEvent, Vec,
 	MILLISECS_PER_BLOCK,
 };
-use frame_support::{parameter_types, traits::Get};
+use frame_support::{parameter_types, traits::Get, weights::Weight};
 use frame_system::EnsureRoot;
 use pallet_parachain_staking::{self as staking, rewards, Config as StakingConfig};
 use pallet_session::{SessionManager, ShouldEndSession};

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -25,7 +25,7 @@ pub use pallet_evm_evolution_collection_factory::REVERT_BYTECODE;
 pub use pallet_parachain_staking::{InflationInfo, Range};
 use precompiles::FrontierPrecompiles;
 use sp_core::U256;
-use sp_runtime::{create_runtime_str, generic, impl_opaque_keys, traits::ConvertInto, Permill};
+use sp_runtime::{create_runtime_str, generic, impl_opaque_keys, Permill};
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -13,10 +13,7 @@ pub mod types;
 mod weights;
 
 use core::marker::PhantomData;
-use frame_support::{
-	construct_runtime,
-	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
-};
+use frame_support::construct_runtime;
 use frame_system::EnsureRoot;
 pub use laos_primitives::{
 	AccountId, AuraId, Balance, BlockNumber, Hash, Header, Nonce, Signature,
@@ -24,7 +21,6 @@ pub use laos_primitives::{
 pub use pallet_evm_evolution_collection_factory::REVERT_BYTECODE;
 pub use pallet_parachain_staking::{InflationInfo, Range};
 use precompiles::FrontierPrecompiles;
-use sp_core::U256;
 use sp_runtime::{create_runtime_str, generic, impl_opaque_keys, Permill};
 use sp_std::prelude::*;
 #[cfg(feature = "std")]


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Refactored imports related to `Weight` and `U256` across various modules for clarity and efficiency.
- Enhanced EVM configuration with new parameters and added unit tests for verifying block gas limit.
- Simplified imports in the runtime library for better maintainability.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apis.rs</strong><dd><code>Refactor Weight Import in APIs Module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/apis.rs
<li>Imported <code>Weight</code> from <code>frame_support</code>.<br> <li> Removed <code>Weight</code> from local module imports, now using the imported one.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/532/files#diff-242fc31d3f7619f16b1efedb812e45586f86917a60cd4d31b46f20cd6edbb71f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base_fee.rs</strong><dd><code>Update U256 Import in Base Fee Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/base_fee.rs
<li>Removed <code>U256</code> from crate imports.<br> <li> Added <code>U256</code> import from <code>sp_core</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/532/files#diff-d0d049daca7fe8882755afb5a29992e216e57d76186e0639c2b491a6c3d986f2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Enhance EVM Configuration and Add Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/evm.rs
<li>Refactored imports and constants for clarity and efficiency.<br> <li> Added new parameter <code>GasLimitPovSizeRatio</code>.<br> <li> Introduced unit tests for block gas limit.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/532/files#diff-705ca1a21913654f820d021a4ab6d046d975864f252f68537584e89bcd379518">+24/-7</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>parachain_staking.rs</strong><dd><code>Refactor Weight Import in Parachain Staking Configuration</code></dd></summary>
<hr>

runtime/laos/src/configs/parachain_staking.rs
- Imported `Weight` from `frame_support`.



</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/532/files#diff-260a47c783c16f4ca58a07f9d05998e138f42333640d8c0e48b7df110a0143d8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Simplify Imports in Runtime Library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs
<li>Simplified imports by removing specific <code>Weight</code> and <code>U256</code> imports.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/532/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

