### PR TITLE
Add `try-runtime` step in CI for `laos-omega`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           SKIP_WASM_BUILD=1 cargo test
 
-  try-runtime-klaos:
+  try-runtime:
     runs-on:
       group: laos
       labels: ubuntu-16-cores

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,10 @@ jobs:
           cargo build --release --locked --package laos --features=try-runtime
       - name: Try Runtime for Klaos
         run: |
-          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://159.223.241.90:9944
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://159.223.241.90:9944
       - name: Try Runtime for Laos Omega
         run: |
-          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://159.223.241.90:9944
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://159.223.241.90:9944
 
   e2e-tests:
     runs-on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
           RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://159.223.241.90:9944
       - name: Try Runtime for Laos Omega
         run: |
-          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://159.223.241.90:9944
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://174.138.104.13:9944
 
   e2e-tests:
     runs-on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,10 @@ jobs:
           cargo build --release --locked --package laos --features=try-runtime
       - name: Try Runtime for Klaos
         run: |
-          RUST_LOG=try-runtime ./target/release/laos try-runtime --chain klaos-dev --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://159.223.241.90:9944
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://159.223.241.90:9944
+      - name: Try Runtime for Laos Omega
+        run: |
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri http://159.223.241.90:9944
 
   e2e-tests:
     runs-on:


### PR DESCRIPTION
Main changes:
- `try-runtime` script for `laos-omega` has been added
- `--chain klaos-dev` has been removed for `klaos` as it doesn't have any effect on the output, similary it hasn't been added to `laos-omega` script.