### PR TITLE
Fix Critical Nonce Type Bug and Add Configuration Comment

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -69,7 +69,7 @@ pub type Balance = u128;
 pub type Moment = u64;
 
 /// Nonce of a transaction in the parachain.
-pub type Nonce = u64;
+pub type Nonce = u32;
 
 /// Weight-to-Fee type used by Laos parachain.
 pub type WeightToFee = IdentityFee<Balance>;
@@ -80,5 +80,5 @@ frame_support::parameter_types! {
 		limits::BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	/// Weight limit of the Laos parachain blocks.
 	pub BlockWeights: limits::BlockWeights =
-		limits::BlockWeights::with_sensible_defaults(MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO);
+		limits::BlockWeights::with_sensible_defaults(MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO); // TODO! Urgent .. this is the setting for a solochain
 }


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- **Critical Bug Fix**: Changed the `Nonce` type from `u64` to `u32` to address a critical issue.
- **Configuration Comment**: Added a comment to `BlockWeights` to highlight the need for urgent review of solochain settings.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Critical Bug Fix and Configuration Comment Addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

primitives/src/lib.rs
<li>Changed <code>Nonce</code> type from <code>u64</code> to <code>u32</code> to fix a critical bug.<br> <li> Added a comment to <code>BlockWeights</code> parameter to indicate an urgent review <br>is needed for solochain settings.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/563/files#diff-93cb951626774323817cabfcdf4c2db9940f66818168e287b6cb9fd725dbb0b0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

