### PR TITLE
Add Comprehensive Unit Tests for BlockWeights Configuration

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -90,11 +90,9 @@ mod tests {
 
 	#[test]
 	fn test_block_weights() {
-		// Assuming BlockWeights::get() is a valid function returning configured BlockWeights
 		let weights = BlockWeights::get();
 
-		// Test base_block and max_block
-		assert_eq!(weights.base_block, Weight::from_parts(390584000, 0)); // Adjusted to your use case
+		assert_eq!(weights.base_block, Weight::from_parts(390584000, 0)); 
 		assert_eq!(weights.max_block, Weight::from_parts(500000000000, 5242880));
 
 		let normal = weights.per_class.get(DispatchClass::Normal);

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -82,3 +82,43 @@ frame_support::parameter_types! {
 	pub BlockWeights: limits::BlockWeights =
 		limits::BlockWeights::with_sensible_defaults(MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO);
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use frame_support::dispatch::DispatchClass;
+
+	#[test]
+	fn test_block_weights() {
+		// Assuming BlockWeights::get() is a valid function returning configured BlockWeights
+		let weights = BlockWeights::get();
+
+		// Test base_block and max_block
+		assert_eq!(weights.base_block, Weight::from_parts(390584000, 0)); // Adjusted to your use case
+		assert_eq!(weights.max_block, Weight::from_parts(500000000000, 5242880));
+
+		let per_class_normal = weights.per_class.get(DispatchClass::Normal);
+		assert_eq!(per_class_normal.base_extrinsic, Weight::from_parts(124414000, 0));
+		assert_eq!(per_class_normal.max_extrinsic, Some(Weight::from_parts(324875586000, 3407872)));
+		assert_eq!(per_class_normal.max_total, Some(Weight::from_parts(375000000000, 3932160)));
+		assert_eq!(per_class_normal.reserved, Some(Weight::from_parts(0, 0)));
+
+		let per_class_mandatory = weights.per_class.get(DispatchClass::Mandatory);
+		assert_eq!(per_class_mandatory.base_extrinsic, Weight::from_parts(124414000, 0));
+		assert_eq!(per_class_mandatory.max_extrinsic, None);
+		assert_eq!(per_class_mandatory.max_total, None);
+		assert_eq!(per_class_mandatory.reserved, None);
+
+		let per_class_operational = weights.per_class.get(DispatchClass::Operational);
+		assert_eq!(per_class_operational.base_extrinsic, Weight::from_parts(124414000, 0));
+		assert_eq!(
+			per_class_operational.max_extrinsic,
+			Some(Weight::from_parts(449875586000, 4718592))
+		);
+		assert_eq!(
+			per_class_operational.max_total,
+			Some(Weight::from_parts(500000000000, 5242880))
+		);
+		assert_eq!(per_class_operational.reserved, Some(Weight::from_parts(125000000000, 1310720)));
+	}
+}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -97,28 +97,22 @@ mod tests {
 		assert_eq!(weights.base_block, Weight::from_parts(390584000, 0)); // Adjusted to your use case
 		assert_eq!(weights.max_block, Weight::from_parts(500000000000, 5242880));
 
-		let per_class_normal = weights.per_class.get(DispatchClass::Normal);
-		assert_eq!(per_class_normal.base_extrinsic, Weight::from_parts(124414000, 0));
-		assert_eq!(per_class_normal.max_extrinsic, Some(Weight::from_parts(324875586000, 3407872)));
-		assert_eq!(per_class_normal.max_total, Some(Weight::from_parts(375000000000, 3932160)));
-		assert_eq!(per_class_normal.reserved, Some(Weight::from_parts(0, 0)));
+		let normal = weights.per_class.get(DispatchClass::Normal);
+		assert_eq!(normal.base_extrinsic, Weight::from_parts(124414000, 0));
+		assert_eq!(normal.max_extrinsic, Some(Weight::from_parts(324875586000, 3407872)));
+		assert_eq!(normal.max_total, Some(Weight::from_parts(375000000000, 3932160)));
+		assert_eq!(normal.reserved, Some(Weight::from_parts(0, 0)));
 
-		let per_class_mandatory = weights.per_class.get(DispatchClass::Mandatory);
-		assert_eq!(per_class_mandatory.base_extrinsic, Weight::from_parts(124414000, 0));
-		assert_eq!(per_class_mandatory.max_extrinsic, None);
-		assert_eq!(per_class_mandatory.max_total, None);
-		assert_eq!(per_class_mandatory.reserved, None);
+		let mandatory = weights.per_class.get(DispatchClass::Mandatory);
+		assert_eq!(mandatory.base_extrinsic, Weight::from_parts(124414000, 0));
+		assert_eq!(mandatory.max_extrinsic, None);
+		assert_eq!(mandatory.max_total, None);
+		assert_eq!(mandatory.reserved, None);
 
-		let per_class_operational = weights.per_class.get(DispatchClass::Operational);
-		assert_eq!(per_class_operational.base_extrinsic, Weight::from_parts(124414000, 0));
-		assert_eq!(
-			per_class_operational.max_extrinsic,
-			Some(Weight::from_parts(449875586000, 4718592))
-		);
-		assert_eq!(
-			per_class_operational.max_total,
-			Some(Weight::from_parts(500000000000, 5242880))
-		);
-		assert_eq!(per_class_operational.reserved, Some(Weight::from_parts(125000000000, 1310720)));
+		let operational = weights.per_class.get(DispatchClass::Operational);
+		assert_eq!(operational.base_extrinsic, Weight::from_parts(124414000, 0));
+		assert_eq!(operational.max_extrinsic, Some(Weight::from_parts(449875586000, 4718592)));
+		assert_eq!(operational.max_total, Some(Weight::from_parts(500000000000, 5242880)));
+		assert_eq!(operational.reserved, Some(Weight::from_parts(125000000000, 1310720)));
 	}
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -92,7 +92,7 @@ mod tests {
 	fn test_block_weights() {
 		let weights = BlockWeights::get();
 
-		assert_eq!(weights.base_block, Weight::from_parts(390584000, 0)); 
+		assert_eq!(weights.base_block, Weight::from_parts(390584000, 0));
 		assert_eq!(weights.max_block, Weight::from_parts(500000000000, 5242880));
 
 		let normal = weights.per_class.get(DispatchClass::Normal);


### PR DESCRIPTION
## **Type**
tests


___

## **Description**
- Introduced comprehensive unit tests for the `BlockWeights` configuration in the `primitives` module.
- These tests validate the correctness of base_block, max_block, and per_class weights for different dispatch classes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Unit Tests for BlockWeights Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

primitives/src/lib.rs
<li>Added a new test module for <code>BlockWeights</code>.<br> <li> Implemented unit tests for base_block, max_block, and per_class <br>weights.<br> <li> Verified the weights for normal, mandatory, and operational dispatch <br>classes.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/564/files#diff-93cb951626774323817cabfcdf4c2db9940f66818168e287b6cb9fd725dbb0b0">+40/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

