### PR TITLE
Align Nonce Type to u32 for Parachain Compatibility

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -69,7 +69,7 @@ pub type Balance = u128;
 pub type Moment = u64;
 
 /// Nonce of a transaction in the parachain.
-pub type Nonce = u64;
+pub type Nonce = u32;
 
 /// Weight-to-Fee type used by Laos parachain.
 pub type WeightToFee = IdentityFee<Balance>;


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Changed the `Nonce` type from `u64` to `u32` in `primitives/src/lib.rs` to ensure compatibility and alignment with parachain standards.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Align `Nonce` Type with Parachain Standards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

primitives/src/lib.rs
<li>Changed the <code>Nonce</code> type from <code>u64</code> to <code>u32</code> to align with parachain <br>standards.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/567/files#diff-93cb951626774323817cabfcdf4c2db9940f66818168e287b6cb9fd725dbb0b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

