### PR TITLE
default network is laos

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -46,7 +46,7 @@ use crate::{
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 	Ok(match id {
-		"laos" => Box::new(chain_spec::laos::ChainSpec::from_json_bytes(
+		"laos" | "" => Box::new(chain_spec::laos::ChainSpec::from_json_bytes(
 			&include_bytes!("../../specs/laos.raw.json")[..],
 		)?),
 		"laos-omega" => Box::new(chain_spec::laos::ChainSpec::from_json_bytes(


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `load_spec` function to handle an empty string as an alias for the "laos" network, ensuring that the default network configuration points to "laos".


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>command.rs</strong><dd><code>Treat empty string as 'laos' network in load_spec function</code></dd></summary>
<hr>

node/src/command.rs
<li>Modified the <code>load_spec</code> function to treat an empty string as an alias <br>for the "laos" network.


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/597/files#diff-8ce03a5a2b79f3021ff2d6322d13448db8cfd5fb9267517ab4b96d0d299ed45f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

