### PR TITLE
remove the filter of EVM and Ethereum pallets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,10 @@ jobs:
           cargo build --release --locked --package laos --features=try-runtime
       - name: Try Runtime for Klaos
         run: |
-          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://159.223.241.90:9944
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri https://159.223.241.90:9944
       - name: Try Runtime for Laos Omega
         run: |
-          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://174.138.104.13:9944
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri https://174.138.104.13:9944
 
   e2e-tests:
     runs-on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,10 @@ jobs:
           cargo build --release --locked --package laos --features=try-runtime
       - name: Try Runtime for Klaos
         run: |
-          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri https://159.223.241.90:9944
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/klaos-runtime/klaos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://159.223.241.90:9944
       - name: Try Runtime for Laos Omega
         run: |
-          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri https://174.138.104.13:9944
+          RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://174.138.104.13:9944
 
   e2e-tests:
     runs-on:

--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -83,10 +83,6 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 		match c {
 			// New candidates are not allowed.
 			RuntimeCall::ParachainStaking(join_candidates { .. }) => false,
-			// Ethereum pallet calls are not allowed.
-			RuntimeCall::Ethereum(_) => false,
-			// EVM pallet calls are not allowed.
-			RuntimeCall::EVM(_) => false,
 			_ => true,
 		}
 	}


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Removed the filters that disallowed EVM and Ethereum pallet calls in the `BaseCallFilter` implementation.
- Updated test cases to reflect the changes in the call filtering logic:
  - Changed the expected outcome of EVM and Ethereum related calls from `CallFiltered` to `BadOrigin` or `Other`.
  - Modified test names to indicate that EVM and Ethereum calls should now be allowed.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system.rs</strong><dd><code>Remove EVM and Ethereum pallet call filters and update tests</code></dd></summary>
<hr>

runtime/laos/src/configs/system.rs
<li>Removed filters for EVM and Ethereum pallet calls in <code>BaseCallFilter</code>.<br> <li> Updated test cases to reflect the removal of these filters.<br> <li> Changed expected errors in test cases from <code>CallFiltered</code> to <code>BadOrigin</code> <br>or <code>Other</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/622/files#diff-fca104f1936302f2739add0ff6a4a5ff2d1d9c14e94d9a15db1f2213a6d843b8">+29/-15</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

