### PR TITLE
some refactoring on Slot type

### DIFF
--- a/pallets/laos-evolution/src/lib.rs
+++ b/pallets/laos-evolution/src/lib.rs
@@ -298,10 +298,12 @@ impl<T: Config> EvolutionCollection<AccountIdOf<T>, TokenUriOf<T>> for Pallet<T>
 fn slot_and_owner_to_token_id(slot: Slot, owner: H160) -> Option<TokenId> {
 	let mut bytes = [0u8; 32];
 
-	let slot_bytes = slot.as_u128().to_be_bytes(); // TODO slot type returns this
+	let slot_u128: u128 = slot.into();
+	let slot_bytes = slot_u128.to_be_bytes(); // TODO slot type returns this
 
-	// we also use the last 12 bytes of the slot, since the first 4 bytes are always 0
+	// Copy the last 12 bytes of the slot into the first 12 bytes of the array
 	bytes[..12].copy_from_slice(&slot_bytes[4..]);
+	// Copy the owner address bytes into the array
 	bytes[12..].copy_from_slice(&owner.0);
 
 	Some(TokenId::from(bytes)) // TODO there is no need to return Option

--- a/pallets/laos-evolution/src/tests.rs
+++ b/pallets/laos-evolution/src/tests.rs
@@ -156,7 +156,7 @@ fn transfer_collection_emits_event() {
 fn slot_and_owner_to_token_id_works() {
 	let slot = Slot::MAX_SLOT;
 	let owner = AccountId::from_str("0x8000000000000000000000000000000000000001").unwrap();
-	let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
+	let token_id = slot_and_owner_to_token_id(slot, owner);
 	assert_eq!(
 		format!("0x{:064x}", token_id),
 		"0xffffffffffffffffffffffff8000000000000000000000000000000000000001"
@@ -182,7 +182,7 @@ fn mint_with_external_uri_works() {
 			token_uri.clone()
 		));
 
-		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
+		let token_id = slot_and_owner_to_token_id(slot, owner);
 
 		assert_eq!(LaosEvolution::token_uri(collection_id, token_id), Some(token_uri.clone()));
 
@@ -199,7 +199,7 @@ fn slot_and_owner_to_asset_id_works() {
 	// and comparing it to an expected value.
 	fn check_token_id(slot: Slot, owner_hex: &str, expected_hex: &str) {
 		let owner = AccountId::from_str(owner_hex).unwrap();
-		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
+		let token_id = slot_and_owner_to_token_id(slot, owner);
 		assert_eq!(format!("0x{:064x}", token_id), expected_hex);
 	}
 
@@ -359,7 +359,7 @@ fn evolve_with_external_uri_when_unexistent_collection_id_should_fail() {
 		let collection_id = LaosEvolution::collection_counter();
 		let slot = Slot::try_from(0).unwrap();
 		let owner = AccountId::from_str(ALICE).unwrap();
-		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
+		let token_id = slot_and_owner_to_token_id(slot, owner);
 		let new_token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();
 
@@ -377,7 +377,7 @@ fn evolve_with_external_uri_when_sender_is_not_collection_owner_should_fail() {
 		let owner = AccountId::from_str(BOB).unwrap();
 		let collection_id = create_collection(BOB);
 		let slot = Slot::try_from(0).unwrap();
-		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
+		let token_id = slot_and_owner_to_token_id(slot, owner);
 		let new_token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();
 
@@ -395,7 +395,7 @@ fn evolve_with_external_uri_when_asset_doesnt_exist_should_fail() {
 		let owner = AccountId::from_str(BOB).unwrap();
 		let collection_id = create_collection(ALICE);
 		let slot = Slot::try_from(0).unwrap();
-		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
+		let token_id = slot_and_owner_to_token_id(slot, owner);
 		let new_token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();
 
@@ -414,7 +414,7 @@ fn evolve_with_external_uri_happy_path() {
 		let owner = AccountId::from_str(BOB).unwrap();
 		let collection_id = create_collection(BOB);
 		let slot = Slot::try_from(0).unwrap();
-		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
+		let token_id = slot_and_owner_to_token_id(slot, owner);
 		let token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();
 		let new_token_uri: TokenUriOf<Test> =
@@ -638,8 +638,7 @@ fn non_collection_owner_cannot_evolve_when_public_minting_is_enabled() {
 		let owner = ALICE;
 		let non_owner = BOB;
 		let slot = 0.try_into().unwrap();
-		let token_id =
-			slot_and_owner_to_token_id(slot, AccountId::from_str(non_owner).unwrap()).unwrap();
+		let token_id = slot_and_owner_to_token_id(slot, AccountId::from_str(non_owner).unwrap());
 
 		create_collection(owner);
 		assert_ok!(LaosEvolution::enable_public_minting(

--- a/pallets/laos-evolution/src/tests.rs
+++ b/pallets/laos-evolution/src/tests.rs
@@ -161,7 +161,7 @@ fn mint_with_external_uri_works() {
 		let collection_id = create_collection(ALICE);
 		let token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();
-		let slot = 0u128.try_into().unwrap();
+		let slot = Slot::try_from(0).unwrap();
 		let owner = AccountId::from_str(ALICE).unwrap();
 
 		assert_ok!(LaosEvolution::mint_with_external_uri(
@@ -210,19 +210,19 @@ fn slot_and_owner_to_asset_id_works() {
 	}
 
 	check_token_id(
-		0_u128.try_into().unwrap(),
+		Slot::try_from(0).unwrap(),
 		"0x0000000000000000000000000000000000000000",
 		"0x0000000000000000000000000000000000000000000000000000000000000000",
 	);
 
 	check_token_id(
-		1_u128.try_into().unwrap(),
+		Slot::try_from(1).unwrap(),
 		"0x0000000000000000000000000000000000000000",
 		"0x0000000000000000000000010000000000000000000000000000000000000000",
 	);
 
 	check_token_id(
-		1_u128.try_into().unwrap(),
+		Slot::try_from(1).unwrap(),
 		"0xe00000000000000000000000000000000000000f",
 		"0x000000000000000000000001e00000000000000000000000000000000000000f",
 	);
@@ -346,7 +346,7 @@ fn token_uri_of_existent_token_returns_correct_token_uri() {
 	new_test_ext().execute_with(|| {
 		let who = AccountId::from_str(ALICE).unwrap();
 		let collection_id = create_collection(ALICE);
-		let slot = 1.try_into().unwrap();
+		let slot = Slot::try_from(1).unwrap();
 		let to = AccountId::from_str(BOB).unwrap();
 		let token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();
@@ -363,7 +363,7 @@ fn evolve_with_external_uri_when_unexistent_collection_id_should_fail() {
 	new_test_ext().execute_with(|| {
 		let who = AccountId::from_str(ALICE).unwrap();
 		let collection_id = LaosEvolution::collection_counter();
-		let slot = 0.try_into().unwrap();
+		let slot = Slot::try_from(0).unwrap();
 		let owner = AccountId::from_str(ALICE).unwrap();
 		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
 		let new_token_uri: TokenUriOf<Test> =
@@ -382,7 +382,7 @@ fn evolve_with_external_uri_when_sender_is_not_collection_owner_should_fail() {
 		let who = AccountId::from_str(ALICE).unwrap();
 		let owner = AccountId::from_str(BOB).unwrap();
 		let collection_id = create_collection(BOB);
-		let slot = 0.try_into().unwrap();
+		let slot = Slot::try_from(0).unwrap();
 		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
 		let new_token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();
@@ -400,7 +400,7 @@ fn evolve_with_external_uri_when_asset_doesnt_exist_should_fail() {
 		let who = AccountId::from_str(ALICE).unwrap();
 		let owner = AccountId::from_str(BOB).unwrap();
 		let collection_id = create_collection(ALICE);
-		let slot = 0.try_into().unwrap();
+		let slot = Slot::try_from(0).unwrap();
 		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
 		let new_token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();
@@ -419,7 +419,7 @@ fn evolve_with_external_uri_happy_path() {
 
 		let owner = AccountId::from_str(BOB).unwrap();
 		let collection_id = create_collection(BOB);
-		let slot = 0.try_into().unwrap();
+		let slot = Slot::try_from(0).unwrap();
 		let token_id = slot_and_owner_to_token_id(slot, owner).unwrap();
 		let token_uri: TokenUriOf<Test> =
 			vec![1, MaxTokenUriLength::get() as u8].try_into().unwrap();

--- a/pallets/laos-evolution/src/types.rs
+++ b/pallets/laos-evolution/src/types.rs
@@ -82,7 +82,9 @@ impl TryFrom<u128> for Slot {
 			Err("Value exceeds 96-bit limit")
 		} else {
 			let bytes = value.to_be_bytes();
-			Ok(Slot(bytes[4..].try_into().unwrap()))
+			let slot_bytes: [u8; 12] =
+				bytes[4..].try_into().map_err(|_| "Slice conversion failed")?;
+			Ok(Slot(slot_bytes))
 		}
 	}
 }

--- a/pallets/laos-evolution/src/types.rs
+++ b/pallets/laos-evolution/src/types.rs
@@ -66,12 +66,6 @@ impl Slot {
 	pub fn new(bytes: [u8; 12]) -> Self {
 		Slot(bytes)
 	}
-
-	pub fn as_u128(&self) -> u128 {
-		let mut bytes = [0u8; 16];
-		bytes[4..].copy_from_slice(&self.0);
-		u128::from_be_bytes(bytes)
-	}
 }
 
 impl TryFrom<u128> for Slot {

--- a/pallets/laos-evolution/src/types.rs
+++ b/pallets/laos-evolution/src/types.rs
@@ -66,6 +66,14 @@ impl Slot {
 	pub fn new(bytes: [u8; 12]) -> Self {
 		Slot(bytes)
 	}
+
+	pub fn to_be_bytes(&self) -> [u8; 12] {
+		let mut bytes = [0u8; 12];
+		let slot_u128: u128 = (*self).into();
+		let slot_bytes = slot_u128.to_be_bytes();
+		bytes.copy_from_slice(&slot_bytes[4..]); // Copy the last 12 bytes
+		bytes
+	}
 }
 
 impl TryFrom<u128> for Slot {

--- a/pallets/laos-evolution/src/types.rs
+++ b/pallets/laos-evolution/src/types.rs
@@ -67,15 +67,6 @@ impl Slot {
 		Slot(bytes)
 	}
 
-	pub fn from_u128(value: u128) -> Result<Self, &'static str> {
-		if value > ((1u128 << 96) - 1) {
-			Err("Value exceeds 96-bit limit")
-		} else {
-			let bytes = value.to_be_bytes();
-			Ok(Slot(bytes[4..].try_into().unwrap()))
-		}
-	}
-
 	pub fn as_u128(&self) -> u128 {
 		let mut bytes = [0u8; 16];
 		bytes[4..].copy_from_slice(&self.0);
@@ -86,8 +77,13 @@ impl Slot {
 impl TryFrom<u128> for Slot {
 	type Error = &'static str;
 
-	fn try_from(num: u128) -> Result<Self, Self::Error> {
-		Slot::from_u128(num)
+	fn try_from(value: u128) -> Result<Self, Self::Error> {
+		if value > ((1u128 << 96) - 1) {
+			Err("Value exceeds 96-bit limit")
+		} else {
+			let bytes = value.to_be_bytes();
+			Ok(Slot(bytes[4..].try_into().unwrap()))
+		}
 	}
 }
 

--- a/pallets/laos-evolution/src/types.rs
+++ b/pallets/laos-evolution/src/types.rs
@@ -26,7 +26,6 @@ use scale_info::{prelude::string::String, TypeInfo};
 use serde::{Deserialize, Serialize};
 use sp_core::U256;
 use sp_runtime::{BoundedVec, RuntimeDebug};
-use sp_std::fmt;
 
 /// Collection id type
 pub type CollectionId = u64;
@@ -76,11 +75,11 @@ impl Slot {
 }
 
 impl TryFrom<u128> for Slot {
-	type Error = SlotError;
+	type Error = &'static str;
 
 	fn try_from(value: u128) -> Result<Self, Self::Error> {
 		if value > ((1u128 << 96) - 1) {
-			Err(SlotError::Exceeds96BitLimit)
+			Err("Value exceeds 96-bit limit")
 		} else {
 			let bytes = value.to_be_bytes();
 			Ok(Slot(bytes[4..].try_into().unwrap()))
@@ -116,21 +115,6 @@ impl Codec for Slot {
 		String::from("uint96")
 	}
 }
-
-#[derive(Debug, PartialEq)]
-pub enum SlotError {
-	Exceeds96BitLimit,
-}
-
-impl fmt::Display for SlotError {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		match self {
-			SlotError::Exceeds96BitLimit => write!(f, "Value exceeds 96-bit limit"),
-		}
-	}
-}
-
-impl std::error::Error for SlotError {}
 
 /// This is a legacy type that is used for compatibility with the legacy Laos EVM Pallets
 /// used in Klaos runtime.
@@ -172,7 +156,7 @@ mod test {
 		let value = 1u128 << 100;
 		let result = Slot::try_from(value);
 		assert!(result.is_err());
-		assert_eq!(result.unwrap_err(), SlotError::Exceeds96BitLimit);
+		assert_eq!(result.unwrap_err(), "Value exceeds 96-bit limit");
 	}
 
 	#[test]

--- a/pallets/laos-evolution/src/types.rs
+++ b/pallets/laos-evolution/src/types.rs
@@ -75,21 +75,6 @@ impl Slot {
 	}
 }
 
-#[derive(Debug, PartialEq)]
-pub enum SlotError {
-	Exceeds96BitLimit,
-}
-
-impl fmt::Display for SlotError {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		match self {
-			SlotError::Exceeds96BitLimit => write!(f, "Value exceeds 96-bit limit"),
-		}
-	}
-}
-
-impl std::error::Error for SlotError {}
-
 impl TryFrom<u128> for Slot {
 	type Error = SlotError;
 
@@ -131,6 +116,21 @@ impl Codec for Slot {
 		String::from("uint96")
 	}
 }
+
+#[derive(Debug, PartialEq)]
+pub enum SlotError {
+	Exceeds96BitLimit,
+}
+
+impl fmt::Display for SlotError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			SlotError::Exceeds96BitLimit => write!(f, "Value exceeds 96-bit limit"),
+		}
+	}
+}
+
+impl std::error::Error for SlotError {}
 
 /// This is a legacy type that is used for compatibility with the legacy Laos EVM Pallets
 /// used in Klaos runtime.


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Removed `SlotOverflow` error variant and simplified the `slot_and_owner_to_token_id` function to directly return `TokenId`.
- Added a new test `slot_and_owner_to_token_id_works` to verify the conversion of `Slot` and owner to `TokenId`.
- Replaced `try_into` with `Slot::try_from` for slot conversions in tests, improving readability and error handling.
- Refactored the `Slot` type by removing the `from_u128` method and adding a `to_be_bytes` method for better byte conversion handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Simplify Slot to TokenId conversion and remove SlotOverflow error</code></dd></summary>
<hr>

pallets/laos-evolution/src/lib.rs
<li>Removed <code>SlotOverflow</code> error variant.<br> <li> Simplified <code>slot_and_owner_to_token_id</code> function to return <code>TokenId</code> <br>directly.<br> <li> Updated <code>slot_and_owner_to_token_id</code> function to handle <code>Slot</code> conversion <br>without overflow checks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/626/files#diff-66efa4b374322a5bdc3d7c2ab9a774a4c545d868a87ee8b24868275cde613088">+8/-10</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.rs</strong><dd><code>Refactor Slot type and remove unnecessary methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pallets/laos-evolution/src/types.rs
<li>Removed <code>Slot::from_u128</code> method.<br> <li> Added <code>Slot::to_be_bytes</code> method.<br> <li> Refactored <code>TryFrom<u128></code> implementation for <code>Slot</code>.<br> <li> Simplified <code>From<Slot></code> implementation for <code>u128</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/626/files#diff-1c0e0f2cebd19a87344afcc27f60687f200f4ff584aeab556cd01a3f8eb6e94b">+18/-16</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs</strong><dd><code>Add tests for Slot to TokenId conversion and refactor existing tests</code></dd></summary>
<hr>

pallets/laos-evolution/src/tests.rs
<li>Added new test <code>slot_and_owner_to_token_id_works</code>.<br> <li> Replaced <code>try_into</code> with <code>Slot::try_from</code> for slot conversions.<br> <li> Removed unnecessary <code>unwrap</code> calls for <code>slot_and_owner_to_token_id</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/626/files#diff-6104a387e08a4830b2d78c0f033d9f5d26c16199a09d531d87a7548cf01f1efd">+29/-36</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

