### PR TITLE
Fix signature enable/disable public minting events

### DIFF
--- a/pallets/laos-evolution/src/precompiles/evolution_collection/mod.rs
+++ b/pallets/laos-evolution/src/precompiles/evolution_collection/mod.rs
@@ -31,10 +31,10 @@ pub const SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI: [u8; 32] =
 pub const SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI: [u8; 32] =
 	keccak256!("EvolvedWithExternalURI(uint256,string)");
 
-/// Solidity selector of the EnabledPublicMinting log, which is the Keccak of the Log signature.
-pub const SELECTOR_LOG_ENABLED_PUBLIC_MINTING: [u8; 32] = keccak256!("EnabledPublicMinting()");
-/// Solidity selector of the DisabledPublicMinting log, which is the Keccak of the Log signature.
-pub const SELECTOR_LOG_DISABLED_PUBLIC_MINTING: [u8; 32] = keccak256!("DisabledPublicMinting()");
+/// Solidity selector of the PublicMintingEnabled log, which is the Keccak of the Log signature.
+pub const SELECTOR_LOG_PUBLIC_MINTING_ENABLED: [u8; 32] = keccak256!("PublicMintingEnabled()");
+/// Solidity selector of the PublicMintingDisabled log, which is the Keccak of the Log signature.
+pub const SELECTOR_LOG_PUBLIC_MINTING_DISABLED: [u8; 32] = keccak256!("PublicMintingDisabled()");
 
 /// Solidity selector of the `OwnershipTransferred` log, which is the Keccak of the Log signature.
 pub const SELECTOR_LOG_OWNERSHIP_TRANSFERRED: [u8; 32] =
@@ -213,7 +213,7 @@ where
 			Ok(()) => {
 				log1(
 					handle.context().address,
-					SELECTOR_LOG_ENABLED_PUBLIC_MINTING,
+					SELECTOR_LOG_PUBLIC_MINTING_ENABLED,
 					solidity::encode_event_data(()),
 				)
 				.record(handle)?;
@@ -238,7 +238,7 @@ where
 			Ok(()) => {
 				log1(
 					handle.context().address,
-					SELECTOR_LOG_DISABLED_PUBLIC_MINTING,
+					SELECTOR_LOG_PUBLIC_MINTING_DISABLED,
 					solidity::encode_event_data(()),
 				)
 				.record(handle)?;

--- a/pallets/laos-evolution/src/precompiles/evolution_collection/tests.rs
+++ b/pallets/laos-evolution/src/precompiles/evolution_collection/tests.rs
@@ -312,7 +312,7 @@ fn enable_public_minting_generates_log() {
 		let collection_address = create_collection(alice);
 		precompiles()
 			.prepare_test(alice, collection_address, PrecompileCall::enable_public_minting {})
-			.expect_log(log1(collection_address, SELECTOR_LOG_ENABLED_PUBLIC_MINTING, vec![]))
+			.expect_log(log1(collection_address, SELECTOR_LOG_PUBLIC_MINTING_ENABLED, vec![]))
 			.execute_some();
 
 		precompiles()
@@ -340,7 +340,7 @@ fn disable_public_minting_generates_log() {
 		let collection_address = create_collection(alice);
 		precompiles()
 			.prepare_test(alice, collection_address, PrecompileCall::disable_public_minting {})
-			.expect_log(log1(collection_address, SELECTOR_LOG_DISABLED_PUBLIC_MINTING, vec![]))
+			.expect_log(log1(collection_address, SELECTOR_LOG_PUBLIC_MINTING_DISABLED, vec![]))
 			.execute_some();
 
 		precompiles()


### PR DESCRIPTION
Signature public minting-related events have been updated to align with those in the [solidity contracts](https://github.com/freeverseio/laos/blob/6f498258bb544fe3732fdd5f5a9e71d5eedc134e/pallets/laos-evolution/src/precompiles/evolution_collection/contracts/EvolutionCollection.sol#L34-L38)