### PR TITLE
Fix QA test missing pvk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,10 +157,3 @@ jobs:
         run: |
           npm run build && npm run test
         working-directory: ./e2e-tests
-
-      - name: Run QA tests
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          npm run qa
-        working-directory: ./e2e-tests
-

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -2,7 +2,6 @@ name: QA
 
 # Controls when the action will run.
 on:
-  push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -2,6 +2,7 @@ name: QA
 
 # Controls when the action will run.
 on:
+  push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -73,6 +73,6 @@ jobs:
 
       - name: Run QA tests
         run: |
-          npm run qa
+          npm run build && npm run qa
         working-directory: ./e2e-tests
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,78 @@
+name: QA
+
+# Controls when the action will run.
+on:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on:
+      group: laos
+      labels: ubuntu-16-cores
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/cache
+        with:
+          cache-key: build_and_push
+      - name: Check
+        run: |
+          cargo check --all-targets --release --features runtime-benchmarks --features try-runtime 
+
+  e2e-tests:
+    runs-on:
+      group: laos
+      labels: ubuntu-16-cores
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/cache
+        with:
+          cache-key: build_and_push
+
+      - name: Build
+        run: |
+          cargo build --release --locked
+
+      - name: Copy polkadot relay chain binary
+        run: |
+          wget https://github.com/paritytech/polkadot/releases/download/v0.9.42/polkadot
+          chmod +x ./polkadot
+      - name: Copy Astar parachain binary
+        run: |
+          wget https://github.com/AstarNetwork/Astar/releases/download/v5.23.0/astar-collator-v5.23.0-ubuntu-x86_64.tar.gz
+          tar xf astar-collator-v5.23.0-ubuntu-x86_64.tar.gz
+          chmod +x ./astar-collator
+
+      - name: Copy zombienet binary
+        run: |
+          wget https://github.com/paritytech/zombienet/releases/download/v1.3.106/zombienet-linux-x64
+          chmod +x ./zombienet-linux-x64
+
+      - name: Run zombienet
+        run: |
+          export ZOMBIENET_RELAYCHAIN_COMMAND=./polkadot
+          export ZOMBIENET_LAOS_COMMAND=./target/release/laos
+          export ZOMBIENET_ASTAR_COMMAND=./astar-collator
+          ./zombienet-linux-x64 spawn ./zombienet/native.toml -p native &
+          echo "Zombienet started"
+
+      - name: Wait for zombienet
+        run: |
+          timeout 36 sh -c 'until nc -z $0 $1; do echo -n .; sleep 1; done' localhost 9999
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: |
+          npm install
+        working-directory: ./e2e-tests
+
+      - name: Run QA tests
+        run: |
+          npm run qa
+        working-directory: ./e2e-tests
+

--- a/e2e-tests/tests/test-evolution.ts
+++ b/e2e-tests/tests/test-evolution.ts
@@ -1,5 +1,5 @@
 import { addressToCollectionId, createCollection, describeWithExistingNode, slotAndOwnerToTokenId } from "./util";
-import { GAS_LIMIT, FAITH, SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_OWNERSHIP_TRANSFERRED, SELECTOR_LOG_PUBLIC_MINTING_ENABLED, SELECTOR_LOG_PUBLIC_MINTING_DISABLED, ALITH } from "./config";
+import { GAS_LIMIT, FAITH, SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_OWNERSHIP_TRANSFERRED, SELECTOR_LOG_PUBLIC_MINTING_ENABLED, SELECTOR_LOG_PUBLIC_MINTING_DISABLED, ALITH, ALITH_PRIVATE_KEY } from "./config";
 import { expect } from "chai";
 import Contract from "web3-eth-contract";
 import BN from "bn.js";
@@ -218,6 +218,7 @@ describeWithExistingNode("@qa Frontier RPC (Public Minting)", (context) => {
         expect(owner).to.be.not.eq(ALITH);
 
         let nonce = await context.web3.eth.getTransactionCount(ALITH);
+        context.web3.eth.accounts.wallet.add(ALITH_PRIVATE_KEY);
         const mintingResult = await collectionContract.methods.mintWithExternalURI(ALITH, "123", "some/random/token/uri").send({ from: ALITH, gas: GAS_LIMIT, nonce: nonce++ });
         expect(mintingResult.status).to.be.eq(true);
     });

--- a/e2e-tests/tests/test-evolution.ts
+++ b/e2e-tests/tests/test-evolution.ts
@@ -1,5 +1,5 @@
 import { addressToCollectionId, createCollection, describeWithExistingNode, slotAndOwnerToTokenId } from "./util";
-import { GAS_LIMIT, FAITH, SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_OWNERSHIP_TRANSFERRED, SELECTOR_LOG_PUBLIC_MINTING_ENABLED, SELECTOR_LOG_PUBLIC_MINTING_DISABLED, ALITH, ALITH_PRIVATE_KEY } from "./config";
+import { GAS_LIMIT, FAITH, SELECTOR_LOG_EVOLVED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_MINTED_WITH_EXTERNAL_TOKEN_URI, SELECTOR_LOG_OWNERSHIP_TRANSFERRED, SELECTOR_LOG_PUBLIC_MINTING_ENABLED, SELECTOR_LOG_PUBLIC_MINTING_DISABLED, ALITH, ALITH_PRIVATE_KEY, EVOLUTION_COLLECTION_ABI } from "./config";
 import { expect } from "chai";
 import Contract from "web3-eth-contract";
 import BN from "bn.js";
@@ -206,9 +206,10 @@ describeWithExistingNode("@qa Frontier RPC (Public Minting)", (context) => {
     step("I can mint even I'm not the owner", async function () {
         const owner = await collectionContract.methods.owner().call();
         expect(owner).to.be.not.eq(ALITH);
-
+        
         let nonce = await context.web3.eth.getTransactionCount(ALITH);
         context.web3.eth.accounts.wallet.add(ALITH_PRIVATE_KEY);
+        collectionContract.options.from = ALITH
         const mintingResult = await collectionContract.methods.mintWithExternalURI(ALITH, "123", "some/random/token/uri").send({ from: ALITH, gas: GAS_LIMIT, nonce: nonce++ });
         expect(mintingResult.status).to.be.eq(true);
     });

--- a/e2e-tests/tests/test-evolution.ts
+++ b/e2e-tests/tests/test-evolution.ts
@@ -134,7 +134,7 @@ describeWithExistingNode("Frontier RPC (Mint and Evolve Assets)", (context) => {
         );
     });
 
-    
+
 });
 
 describeWithExistingNode("@qa Frontier RPC (Public Minting)", (context) => {
@@ -169,7 +169,7 @@ describeWithExistingNode("@qa Frontier RPC (Public Minting)", (context) => {
         try {
             await collectionContract.methods.transferOwnership(FAITH).send({ from: FAITH, gas: GAS_LIMIT });
             expect.fail("Expected error was not thrown"); // Ensure an error is thrown
-        } catch (error) {}
+        } catch (error) { }
 
     });
 
@@ -188,8 +188,7 @@ describeWithExistingNode("@qa Frontier RPC (Public Minting)", (context) => {
         expect(disablingPublicMintingResult.events.PublicMintingDisabled.raw.data).to.be.eq('0x');
     });
 
-    step("after enable it I can disable", async function () {
-        // enable
+    step("enable public minting emits an event", async function () {
         const enablingPublicMintingResult = await collectionContract.methods.enablePublicMinting().send({ from: FAITH, gas: GAS_LIMIT });
         expect(enablingPublicMintingResult.status).to.be.eq(true);
         expect(await collectionContract.methods.isPublicMintingEnabled().call()).to.be.eq(true);
@@ -202,15 +201,6 @@ describeWithExistingNode("@qa Frontier RPC (Public Minting)", (context) => {
         // enable twice has no effect
         await collectionContract.methods.enablePublicMinting().send({ from: FAITH, gas: GAS_LIMIT });
         expect(await collectionContract.methods.isPublicMintingEnabled().call()).to.be.eq(true);
-
-        // disable
-        const disablingPublicMintingResult = await collectionContract.methods.disablePublicMinting().send({ from: FAITH, gas: GAS_LIMIT });
-        expect(disablingPublicMintingResult.status).to.be.eq(true);
-        expect(await collectionContract.methods.isPublicMintingEnabled().call()).to.be.eq(false);
-        expect(Object.keys(disablingPublicMintingResult.events).length).to.be.eq(1);
-        expect(disablingPublicMintingResult.events.PublicMintingDisabled.raw.topics.length).to.be.eq(1);
-        expect(disablingPublicMintingResult.events.PublicMintingDisabled.raw.topics[0]).to.be.eq(SELECTOR_LOG_PUBLIC_MINTING_DISABLED);
-        expect(disablingPublicMintingResult.events.PublicMintingDisabled.raw.data).to.be.eq('0x');
     });
 
     step("I can mint even I'm not the owner", async function () {
@@ -221,6 +211,16 @@ describeWithExistingNode("@qa Frontier RPC (Public Minting)", (context) => {
         context.web3.eth.accounts.wallet.add(ALITH_PRIVATE_KEY);
         const mintingResult = await collectionContract.methods.mintWithExternalURI(ALITH, "123", "some/random/token/uri").send({ from: ALITH, gas: GAS_LIMIT, nonce: nonce++ });
         expect(mintingResult.status).to.be.eq(true);
+    });
+
+    step("after enabling I can disable", async function () {
+        const disablingPublicMintingResult = await collectionContract.methods.disablePublicMinting().send({ from: FAITH, gas: GAS_LIMIT });
+        expect(disablingPublicMintingResult.status).to.be.eq(true);
+        expect(await collectionContract.methods.isPublicMintingEnabled().call()).to.be.eq(false);
+        expect(Object.keys(disablingPublicMintingResult.events).length).to.be.eq(1);
+        expect(disablingPublicMintingResult.events.PublicMintingDisabled.raw.topics.length).to.be.eq(1);
+        expect(disablingPublicMintingResult.events.PublicMintingDisabled.raw.topics[0]).to.be.eq(SELECTOR_LOG_PUBLIC_MINTING_DISABLED);
+        expect(disablingPublicMintingResult.events.PublicMintingDisabled.raw.data).to.be.eq('0x');
     });
 
     step("after changing owner I can't disable", async function () {


### PR DESCRIPTION
Besides accomplishing what the title suggests, the QA step, which was part of the build workflow, has been moved to a separate workflow. This prevents the execution of unnecessary jobs (lint, check, try-runtime, etc.) within the QA process.