### PR TITLE
Enable permissionless collators by modifying `BaseCallFilter` and updating tests

### DIFF
--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -18,7 +18,7 @@ use crate::{
 	weights::RocksDbWeight, AccountId, Balance, Block, PalletInfo, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, RuntimeVersion, VERSION,
 };
-use frame_support::parameter_types;
+use frame_support::{parameter_types, traits::Contains};
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 parameter_types! {
@@ -61,7 +61,7 @@ impl frame_system::Config for Runtime {
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = ();
+	type BaseCallFilter = BaseCallFilter;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = ();
 	/// Block & extrinsics weights: base values and limits.
@@ -73,6 +73,13 @@ impl frame_system::Config for Runtime {
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+pub struct BaseCallFilter;
+impl Contains<RuntimeCall> for BaseCallFilter {
+	fn contains(_: &RuntimeCall) -> bool {
+		true
+	}
 }
 
 // tests

--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -89,7 +89,6 @@ mod tests {
 	use crate::{
 		currency::UNIT,
 		tests::{new_test_ext, ExtBuilder, ALICE, BOB},
-		Runtime,
 	};
 	use core::str::FromStr;
 	use frame_support::{assert_err, assert_ok, dispatch::PostDispatchInfo, pallet_prelude::Pays};
@@ -198,10 +197,16 @@ mod tests {
 	}
 
 	#[test]
-	fn join_candidates_should_not_be_allowed() {
+	fn join_candidates_should_be_allowed() {
 		new_test_ext().execute_with(|| {
 			let account = AccountId::from_str(ALICE).unwrap();
-			let stake = 100_000;
+			let stake = 20_000 * UNIT;
+
+			assert_ok!(pallet_balances::Pallet::<Runtime>::force_set_balance(
+				RuntimeOrigin::root(),
+				account,
+				stake
+			));
 
 			let call =
 				RuntimeCall::ParachainStaking(pallet_parachain_staking::Call::join_candidates {
@@ -209,10 +214,7 @@ mod tests {
 					candidate_count: 32,
 				});
 
-			assert_err!(
-				call.dispatch(RuntimeOrigin::signed(account)),
-				frame_system::Error::<Runtime>::CallFiltered
-			);
+			assert_ok!(call.dispatch(RuntimeOrigin::signed(account)));
 		});
 	}
 

--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -18,7 +18,7 @@ use crate::{
 	weights::RocksDbWeight, AccountId, Balance, Block, PalletInfo, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, RuntimeVersion, VERSION,
 };
-use frame_support::{parameter_types, traits::Contains};
+use frame_support::{parameter_types, traits::Everything};
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 parameter_types! {
@@ -61,7 +61,7 @@ impl frame_system::Config for Runtime {
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = BaseCallFilter;
+	type BaseCallFilter = Everything;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = ();
 	/// Block & extrinsics weights: base values and limits.
@@ -73,13 +73,6 @@ impl frame_system::Config for Runtime {
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
-}
-
-pub struct BaseCallFilter;
-impl Contains<RuntimeCall> for BaseCallFilter {
-	fn contains(_: &RuntimeCall) -> bool {
-		true
-	}
 }
 
 // tests

--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -18,7 +18,7 @@ use crate::{
 	weights::RocksDbWeight, AccountId, Balance, Block, PalletInfo, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, RuntimeVersion, VERSION,
 };
-use frame_support::{parameter_types, traits::Contains};
+use frame_support::parameter_types;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 parameter_types! {
@@ -61,7 +61,7 @@ impl frame_system::Config for Runtime {
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = BaseCallFilter;
+	type BaseCallFilter = ();
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = ();
 	/// Block & extrinsics weights: base values and limits.
@@ -73,19 +73,6 @@ impl frame_system::Config for Runtime {
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
-}
-
-pub struct BaseCallFilter;
-impl Contains<RuntimeCall> for BaseCallFilter {
-	fn contains(c: &RuntimeCall) -> bool {
-		use pallet_parachain_staking::Call::*;
-
-		match c {
-			// New candidates are not allowed.
-			RuntimeCall::ParachainStaking(join_candidates { .. }) => false,
-			_ => true,
-		}
-	}
 }
 
 // tests


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Removed the filter for `join_candidates` in `BaseCallFilter`, allowing new candidates to join.
- Simplified the `contains` method in `BaseCallFilter` to always return `true`.
- Updated the test to ensure `join_candidates` is allowed and dispatches successfully.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system.rs</strong><dd><code>Allow permissionless collators by modifying `BaseCallFilter`</code></dd></summary>
<hr>

runtime/laos/src/configs/system.rs

<li>Removed the filter for <code>join_candidates</code> in <code>BaseCallFilter</code>.<br> <li> Simplified the <code>contains</code> method to always return <code>true</code>.<br> <li> Updated test to allow <code>join_candidates</code> and check for successful <br>dispatch.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/674/files#diff-fca104f1936302f2739add0ff6a4a5ff2d1d9c14e94d9a15db1f2213a6d843b8">+11/-15</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

