### PR TITLE
Run e2e tests on main and tags only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Check clippy
         run: |
           SKIP_WASM_BUILD=1 cargo clippy --all-targets --workspace --features runtime-benchmarks --features try-runtime -- -D warnings
+
   test:
     runs-on:
       group: laos
@@ -100,60 +101,3 @@ jobs:
       - name: Try Runtime for Laos Omega
         run: |
           RUST_LOG=try-runtime ./target/release/laos try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --checks=pre-and-post live --uri ws://174.138.104.13:9944
-
-  e2e-tests:
-    runs-on:
-      group: laos
-      labels: ubuntu-16-cores
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/cache
-        with:
-          cache-key: build_and_push
-
-      - name: Build
-        run: |
-          cargo build --release --locked
-
-      - name: Copy polkadot relay chain binary
-        run: |
-          wget https://github.com/paritytech/polkadot/releases/download/v0.9.42/polkadot
-          chmod +x ./polkadot
-      - name: Copy Astar parachain binary
-        run: |
-          wget https://github.com/AstarNetwork/Astar/releases/download/v5.23.0/astar-collator-v5.23.0-ubuntu-x86_64.tar.gz
-          tar xf astar-collator-v5.23.0-ubuntu-x86_64.tar.gz
-          chmod +x ./astar-collator
-
-      - name: Copy zombienet binary
-        run: |
-          wget https://github.com/paritytech/zombienet/releases/download/v1.3.106/zombienet-linux-x64
-          chmod +x ./zombienet-linux-x64
-
-      - name: Run zombienet
-        run: |
-          export ZOMBIENET_RELAYCHAIN_COMMAND=./polkadot
-          export ZOMBIENET_LAOS_COMMAND=./target/release/laos
-          export ZOMBIENET_ASTAR_COMMAND=./astar-collator
-          ./zombienet-linux-x64 spawn ./zombienet/native.toml -p native &
-          echo "Zombienet started"
-
-      - name: Wait for zombienet
-        run: |
-          timeout 36 sh -c 'until nc -z $0 $1; do echo -n .; sleep 1; done' localhost 9999
-
-      - name: Use Node.js 18
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Install dependencies
-        run: |
-          npm install
-        working-directory: ./e2e-tests
-
-      - name: Run tests
-        run: |
-          npm run build && npm run test
-        working-directory: ./e2e-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 name: Build
 
-# Controls when the action will run.
 on:
   push:
   workflow_dispatch:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,24 +1,10 @@
-name: QA
+name: E2E Tests
 
-# Controls when the action will run.
 on:
+  workflow_call:
   workflow_dispatch:
 
 jobs:
-  check:
-    runs-on:
-      group: laos
-      labels: ubuntu-16-cores
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/cache
-        with:
-          cache-key: build_and_push
-      - name: Check
-        run: |
-          cargo check --all-targets --release --features runtime-benchmarks --features try-runtime 
-
   e2e-tests:
     runs-on:
       group: laos
@@ -71,8 +57,7 @@ jobs:
           npm install
         working-directory: ./e2e-tests
 
-      - name: Run QA tests
+      - name: Run e2e tests
         run: |
-          npm run build && npm run qa
+          npm run build && npm run test
         working-directory: ./e2e-tests
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,10 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  e2e-tests:
+    uses: ./.github/workflows/e2e.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Main
 on:
   push:
     branches:
-      - 'main'
+      - 'feature/change-e2e-tests-ci'
 
 jobs:
   e2e-tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Main
 on:
   push:
     branches:
-      - 'feature/change-e2e-tests-ci'
+      - 'main'
 
 jobs:
   e2e-tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,12 @@ jobs:
     outputs:
       is_release_version: ${{ steps.check_version.outputs.is_release_version }}
 
-  prepare-release:
+  e2e-tests:
     needs: check-version
+    uses: ./.github/workflows/e2e.yml
+
+  prepare-release:
+    needs: e2e-tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -113,7 +117,9 @@ jobs:
             fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   dockerize_and_push:
+    needs: prepare-release
     runs-on: 
       group: laos
       labels: ubuntu-16-cores

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,7 +7,7 @@
 		"fmt-check": "prettier ./tests --check",
 		"fmt": "prettier ./tests --write",
 		"build": "cp -r ../pallets/laos-evolution/src/precompiles/evolution_collection_factory/contracts contracts && cp -r ../pallets/laos-evolution/src/precompiles/evolution_collection/contracts contracts && cp -r ../pallets/asset-metadata-extender/src/precompiles/asset_metadata_extender/contracts contracts && truffle compile && rm -rf contracts",
-		"test": "mocha -r ts-node/register 'tests/**/*.ts'",
+		"test": "mocha -r ts-node/register -t 270000 'tests/**/*.ts'",
 		"test-sql": "FRONTIER_BACKEND_TYPE='sql' mocha -r ts-node/register 'tests/**/*.ts'"
 	},
 	"author": "",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,8 +7,7 @@
 		"fmt-check": "prettier ./tests --check",
 		"fmt": "prettier ./tests --write",
 		"build": "cp -r ../pallets/laos-evolution/src/precompiles/evolution_collection_factory/contracts contracts && cp -r ../pallets/laos-evolution/src/precompiles/evolution_collection/contracts contracts && cp -r ../pallets/asset-metadata-extender/src/precompiles/asset_metadata_extender/contracts contracts && truffle compile && rm -rf contracts",
-		"test": "mocha -r ts-node/register -t 70000 --grep '@qa' --invert 'tests/**/*.ts'",
-		"qa": "mocha -r ts-node/register -t 200000 --grep '@qa' 'tests/**/*.ts'",
+		"test": "mocha -r ts-node/register 'tests/**/*.ts'",
 		"test-sql": "FRONTIER_BACKEND_TYPE='sql' mocha -r ts-node/register 'tests/**/*.ts'"
 	},
 	"author": "",


### PR DESCRIPTION
https://github.com/freeverseio/laos/issues/669

- The e2e tests workflow is in a separate file so it can be reused by both the `release` and `main` flows via the [`workflow_call`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_call) instruction (coming from [this page](https://docs.github.com/en/actions/using-workflows/reusing-workflows))
- The e2e tests can be triggered manually via the [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) instruction
- No more `@qa` tag on the e2e tests
- Extra: all the jobs in the release flow are now sequential to avoid releasing in case anything fails

As you can see [here](https://github.com/freeverseio/laos/actions/runs/9990195717/) and [here](https://github.com/freeverseio/laos/actions/runs/9991500758), the filter works as intended