### PR TITLE
Update fork documentation with commit hash and source link

### DIFF
--- a/pallets/parachain-staking/README.md
+++ b/pallets/parachain-staking/README.md
@@ -1,6 +1,6 @@
 # DPoS Pallet for Parachain Staking
 
-This pallet is forked from `moonbeam` to avoid dependency on it. The exact commit hash of the fork is tag [`v0.36.0`](https://github.com/moonbeam-foundation/moonbeam/tree/v0.36.0/pallets/parachain-staking);
+This pallet is forked from [`moonbeam v0.36.0`](https://github.com/moonbeam-foundation/moonbeam/tree/v0.36.0/pallets/parachain-staking), commit hash `d1087f3091726ffbe14b44655d848d00a1f14201`.
 
 ## Formatting Rules
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Updated the fork documentation in `pallets/parachain-staking/README.md` to include the specific commit hash `d1087f3091726ffbe14b44655d848d00a1f14201`.
- Clarified the source of the fork by providing a direct link to the `moonbeam v0.36.0` tag.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update fork documentation with commit hash and source link</code></dd></summary>
<hr>

pallets/parachain-staking/README.md

<li>Updated the fork documentation to include the specific commit hash.<br> <li> Clarified the source of the fork with a direct link.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/676/files#diff-0fca65083c9c2844f921e8a9c544dcc68c90a356ba571016627799148271dec8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

