### PR TITLE
Add condition to run E2E tests on PR review approval

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,12 +3,15 @@ name: E2E Tests
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   e2e-tests:
     runs-on:
       group: laos
       labels: ubuntu-16-cores
+    if: ${{ github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a condition in the GitHub Actions workflow to trigger E2E tests when a pull request review is submitted and approved.
- Modified the E2E test job to run only if the review state is 'approved' or if manually triggered via workflow dispatch.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e.yml</strong><dd><code>Add condition to run E2E tests on PR review approval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e.yml

<li>Added condition to trigger E2E tests on pull request review <br>submission.<br> <li> Modified job to run only if the review state is 'approved' or <br>triggered manually.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/693/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

