### PR TITLE
Prepare release v0.18.0 with updated runtime spec_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,7 +4969,7 @@ dependencies = [
 
 [[package]]
 name = "laos"
-version = "0.17.3"
+version = "0.18.0"
 dependencies = [
  "clap",
  "cumulus-client-cli",
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "laos-runtime"
-version = "0.17.3"
+version = "0.18.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ description = "The LAOS parachain node."
 repository = "https://github.com/freeverseio/laos.git"
 homepage = "https://www.laosfoundation.io"
 authors = ["Freeverse"]
-version = "0.17.3"
+version = "0.18.0"
 
 [workspace]
 resolver = "2"

--- a/e2e-tests/tests/config.ts
+++ b/e2e-tests/tests/config.ts
@@ -8,7 +8,7 @@ import ParachainStaking from "../build/contracts/ParachainStaking.json";
 
 // Node config
 export const RUNTIME_SPEC_NAME = "laos";
-export const RUNTIME_SPEC_VERSION = 1703;
+export const RUNTIME_SPEC_VERSION = 1800;
 export const RUNTIME_IMPL_VERSION = 0;
 export const LOCAL_NODE_URL = "http://127.0.0.1:9999";
 

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("laos"),
 	impl_name: create_runtime_str!("laos"),
 	authoring_version: 1,
-	spec_version: 1703,
+	spec_version: 1800,
 	impl_version: 0,
 	apis: apis::PUBLIC_RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
### **PR Type**
Enhancement, Other


___

### **Description**
- Updated `spec_version` in `runtime/laos/src/lib.rs` from 1703 to 1800.
- Updated `RUNTIME_SPEC_VERSION` in `e2e-tests/tests/config.ts` from 1703 to 1800.
- Bumped package version in `Cargo.toml` from 0.17.3 to 0.18.0.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Update runtime spec_version to 1800</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs

- Updated `spec_version` from 1703 to 1800.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/697/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Update e2e test configuration spec_version to 1800</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e-tests/tests/config.ts

- Updated `RUNTIME_SPEC_VERSION` from 1703 to 1800.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/697/files#diff-17ac7a48df24b9162d8a294aef70b86a0a2e0d7e01055c65876c51668a0482c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Other</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump package version to 0.18.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Updated package version from 0.17.3 to 0.18.0.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/697/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

