### PR TITLE
Add Technical Committee to Runtime and Configurations

### DIFF
--- a/runtime/laos/src/configs/collective_council.rs
+++ b/runtime/laos/src/configs/collective_council.rs
@@ -1,10 +1,9 @@
+use super::MaxCollectivesProposalWeight;
 use crate::{
 	weights, AccountId, BlockNumber, EnsureRoot, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
 };
-use frame_support::{pallet_prelude::Weight, parameter_types};
-use laos_primitives::RuntimeBlockWeights;
+use frame_support::parameter_types;
 use parachains_common::DAYS;
-use sp_runtime::Perbill;
 
 const COUNCIL_MOTION_DURATION: BlockNumber = 7 * DAYS;
 
@@ -12,8 +11,6 @@ parameter_types! {
 	pub const CouncilMotionDuration: BlockNumber = COUNCIL_MOTION_DURATION;
 	pub const CouncilMaxProposals: u32 = 7;
 	pub const CouncilMaxMembers: u32 = 20;
-	pub MaxProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
-	pub MaxCollectivesProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
 }
 
 type CouncilCollective = pallet_collective::Instance1;

--- a/runtime/laos/src/configs/collective_technical.rs
+++ b/runtime/laos/src/configs/collective_technical.rs
@@ -1,10 +1,9 @@
+use super::MaxCollectivesProposalWeight;
 use crate::{
 	AccountId, BlockNumber, EnsureRoot, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
 };
-use frame_support::{pallet_prelude::Weight, parameter_types};
-use laos_primitives::RuntimeBlockWeights;
+use frame_support::parameter_types;
 use parachains_common::DAYS;
-use sp_runtime::Perbill;
 
 const TECHNICAL_MOTION_DURATION: BlockNumber = 7 * DAYS;
 
@@ -12,8 +11,6 @@ parameter_types! {
 	pub const TechnicalMotionDuration: BlockNumber = TECHNICAL_MOTION_DURATION;
 	pub const TechnicalMaxProposals: u32 = 7;
 	pub const TechnicalMaxMembers: u32 = 5;
-	pub MaxProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
-	pub MaxCollectivesProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
 }
 
 type TechnicalCollective = pallet_collective::Instance2;

--- a/runtime/laos/src/configs/collective_technical.rs
+++ b/runtime/laos/src/configs/collective_technical.rs
@@ -1,0 +1,31 @@
+use crate::{
+	AccountId, BlockNumber, EnsureRoot, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
+};
+use frame_support::{pallet_prelude::Weight, parameter_types};
+use laos_primitives::RuntimeBlockWeights;
+use parachains_common::DAYS;
+use sp_runtime::Perbill;
+
+const TECHNICAL_MOTION_DURATION: BlockNumber = 7 * DAYS;
+
+parameter_types! {
+	pub const TechnicalMotionDuration: BlockNumber = TECHNICAL_MOTION_DURATION;
+	pub const TechnicalMaxProposals: u32 = 7;
+	pub const TechnicalMaxMembers: u32 = 5;
+	pub MaxProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
+	pub MaxCollectivesProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
+}
+
+type TechnicalCollective = pallet_collective::Instance2;
+impl pallet_collective::Config<TechnicalCollective> for Runtime {
+	type DefaultVote = pallet_collective::MoreThanMajorityThenPrimeDefaultVote;
+	type MaxMembers = TechnicalMaxMembers;
+	type MaxProposalWeight = MaxCollectivesProposalWeight;
+	type MaxProposals = TechnicalMaxProposals;
+	type MotionDuration = TechnicalMotionDuration;
+	type Proposal = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+	type SetMembersOrigin = EnsureRoot<AccountId>;
+	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
+}

--- a/runtime/laos/src/configs/mod.rs
+++ b/runtime/laos/src/configs/mod.rs
@@ -21,6 +21,7 @@ mod balances;
 mod base_fee;
 mod benchmark;
 mod collective_council;
+mod collective_technical;
 mod cumulus_dmp_queue;
 mod cumulus_parachain_system;
 mod cumulus_xcmp_queue;

--- a/runtime/laos/src/configs/mod.rs
+++ b/runtime/laos/src/configs/mod.rs
@@ -41,13 +41,16 @@ mod utility;
 mod vesting;
 pub(crate) mod xcm_config;
 
-use frame_support::parameter_types;
+use frame_support::{pallet_prelude::Weight, parameter_types};
+use laos_primitives::RuntimeBlockWeights;
+use sp_runtime::Perbill;
 
 use crate::Runtime;
 
 parameter_types! {
 	/// Max length of the `TokenUri`
 	pub const MaxTokenUriLength: u32 = 512;
+	pub MaxCollectivesProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
 }
 
 impl cumulus_pallet_aura_ext::Config for Runtime {}

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -132,6 +132,7 @@ construct_runtime!(
 
 		// Governance
 		Council: pallet_collective::<Instance1> = 42,
+		TechnicalCommittee: pallet_collective::<Instance2> = 43,
 		Preimage: pallet_preimage = 45,
 
 		// Frontier


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `collective_technical` module to the configurations.
- Integrated `TechnicalCommittee` into the runtime.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add `collective_technical` module to configurations.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/mod.rs

- Added `collective_technical` module.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/717/files#diff-450b756d1af9090dd62cc432c3c21a1a4f655d52ee8b477c3d81e1038434d68b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Integrate `TechnicalCommittee` into runtime.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs

- Added `TechnicalCommittee` to the runtime.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/717/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

