### PR TITLE
Update treasury council majority requirements for decision making

### DIFF
--- a/runtime/laos/src/configs/treasury.rs
+++ b/runtime/laos/src/configs/treasury.rs
@@ -34,14 +34,10 @@ parameter_types! {
 	pub TreasuryAccount: AccountId = Treasury::account_id();
 }
 
-type ApproveOrigin = EitherOfDiverse<
-	EnsureRoot<AccountId>,
-	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
->;
-type RejectOrigin = EitherOfDiverse<
-	EnsureRoot<AccountId>,
-	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
->;
+type CouncilMajority =
+	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>;
+type ApproveOrigin = EitherOfDiverse<EnsureRoot<AccountId>, CouncilMajority>;
+type RejectOrigin = EitherOfDiverse<EnsureRoot<AccountId>, CouncilMajority>;
 
 impl pallet_treasury::Config for Runtime {
 	type AssetKind = ();

--- a/runtime/laos/src/configs/treasury.rs
+++ b/runtime/laos/src/configs/treasury.rs
@@ -36,11 +36,11 @@ parameter_types! {
 
 type ApproveOrigin = EitherOfDiverse<
 	EnsureRoot<AccountId>,
-	pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 1>,
+	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
 >;
 type RejectOrigin = EitherOfDiverse<
 	EnsureRoot<AccountId>,
-	pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 2>,
+	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>,
 >;
 
 impl pallet_treasury::Config for Runtime {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `ApproveOrigin` and `RejectOrigin` logic in the treasury configuration to require a stricter council majority, changing from `EnsureProportionAtLeast` to `EnsureProportionMoreThan`.
- This change affects how decisions are approved or rejected by the council, requiring more than half of the council members instead of at least half.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>treasury.rs</strong><dd><code>Modify council majority requirements for treasury decisions</code></dd></summary>
<hr>

runtime/laos/src/configs/treasury.rs

<li>Changed <code>ApproveOrigin</code> to require more than half of the council's <br>approval.<br> <li> Changed <code>RejectOrigin</code> to require more than half of the council's <br>approval.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/757/files#diff-094b4a74f7e7a446c70dd2ca710d6a7c87a1c46369ec9a8125621479e247219a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

