### PR TITLE
Add telemetry endpoints to laos configurations

### DIFF
--- a/specs/laos-mercury.raw.json
+++ b/specs/laos-mercury.raw.json
@@ -5,7 +5,12 @@
   "bootNodes": [
     "/dns4/laosmercury-boot-0.gorengine.com/tcp/30334/p2p/12D3KooWMfJKXB9JPKctMfZBe7u6HtTcwLPy1J1D4saT1HKisr5S"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
+    ]
+  ],
   "protocolId": "laos_mercury_testnet",
   "properties": {
     "ss58Format": 42,

--- a/specs/laos-sigma.raw.json
+++ b/specs/laos-sigma.raw.json
@@ -3,7 +3,12 @@
   "id": "laos_sigma_testnet",
   "chainType": "Live",
   "bootNodes": ["/dns4/laossigma-boot-0.gorengine.com/tcp/30334/p2p/12D3KooWBMM8gJxomycSLjnNnNAVUMEFhBPfBECvT9NvAhPBreRq"],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
+    ]
+  ],
   "protocolId": "laos_sigma_testnet",
   "properties": {
     "ss58Format": 42,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added telemetry endpoints to the `laos-mercury` and `laos-sigma` configurations.
- Updated the `telemetryEndpoints` field from `null` to include a new endpoint for both configurations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>laos-mercury.raw.json</strong><dd><code>Add telemetry endpoints to laos-mercury configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

specs/laos-mercury.raw.json

<li>Added telemetry endpoints to the configuration.<br> <li> Updated the <code>telemetryEndpoints</code> field from <code>null</code> to include a new <br>endpoint.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/762/files#diff-ad13da2359347b6de2898b6fec962e6eb33f48c633b5074f3f4b6c2585f88d97">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>laos-sigma.raw.json</strong><dd><code>Add telemetry endpoints to laos-sigma configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

specs/laos-sigma.raw.json

<li>Added telemetry endpoints to the configuration.<br> <li> Updated the <code>telemetryEndpoints</code> field from <code>null</code> to include a new <br>endpoint.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/762/files#diff-c9d2d7e4fde7aeb6a09272814bbf12990a9401ffaae30a1d9d320168fae67d66">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

