### PR TITLE
Streamline configuration with `prod_or_fast!` macro for time durations

### DIFF
--- a/runtime/laos/src/configs/collective.rs
+++ b/runtime/laos/src/configs/collective.rs
@@ -2,19 +2,12 @@ use crate::{weights, AccountId, BlockNumber, Runtime, RuntimeCall, RuntimeEvent,
 use frame_support::{pallet_prelude::Weight, parameter_types, traits::EitherOfDiverse};
 use frame_system::EnsureRoot;
 use laos_primitives::RuntimeBlockWeights;
-#[cfg(not(feature = "fast-mode"))]
-use parachains_common::DAYS;
-#[cfg(feature = "fast-mode")]
-use parachains_common::MINUTES;
+use parachains_common::{DAYS, MINUTES};
+use polkadot_runtime_common::prod_or_fast;
 use sp_runtime::Perbill;
 
-#[cfg(feature = "fast-mode")]
-pub const MOTION_DURATION: BlockNumber = 5 * MINUTES;
-#[cfg(not(feature = "fast-mode"))]
-pub const MOTION_DURATION: BlockNumber = 7 * DAYS;
-
 parameter_types! {
-	pub const MotionDuration: BlockNumber = MOTION_DURATION;
+	pub const MotionDuration: BlockNumber = prod_or_fast!(7 * DAYS, 5 * MINUTES);
 	pub const MaxProposals: u32 = 7;
 	pub const MaxMembers: u32 = 20;
 	pub MaxProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;

--- a/runtime/laos/src/configs/election_phragmen.rs
+++ b/runtime/laos/src/configs/election_phragmen.rs
@@ -3,26 +3,13 @@ use crate::{
 	Treasury,
 };
 use frame_support::{parameter_types, traits::LockIdentifier};
-#[cfg(not(feature = "fast-mode"))]
-use parachains_common::DAYS;
-#[cfg(feature = "fast-mode")]
-use parachains_common::MINUTES;
-use polkadot_runtime_common::CurrencyToVote;
-
-#[cfg(feature = "fast-mode")]
-pub const TERM_DURATION: BlockNumber = 10 * MINUTES;
-#[cfg(not(feature = "fast-mode"))]
-pub const TERM_DURATION: BlockNumber = 28 * DAYS;
-
-#[cfg(feature = "fast-mode")]
-pub const ELECTION_VOTING_LOCK_DURATION: BlockNumber = 10 * MINUTES;
-#[cfg(not(feature = "fast-mode"))]
-pub const ELECTION_VOTING_LOCK_DURATION: BlockNumber = 28 * DAYS;
+use parachains_common::{DAYS, MINUTES};
+use polkadot_runtime_common::{prod_or_fast, CurrencyToVote};
 
 parameter_types! {
 	pub const CandidacyBond: Balance = 1000 * UNIT;
-	pub TermDuration: BlockNumber = TERM_DURATION;
-	pub VotingLockPeriod: BlockNumber = ELECTION_VOTING_LOCK_DURATION;
+	pub TermDuration: BlockNumber = prod_or_fast!(28 * DAYS, 10 * MINUTES);
+	pub VotingLockPeriod: BlockNumber = prod_or_fast!(28 * DAYS, 10 * MINUTES);
 	pub const DesiredMembers: u32 = 7;
 	pub const DesiredRunnersUp: u32 = 20;
 	pub const MaxCandidates: u32 = 30;

--- a/runtime/laos/src/configs/treasury.rs
+++ b/runtime/laos/src/configs/treasury.rs
@@ -12,22 +12,15 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::EnsureRoot;
-#[cfg(not(feature = "fast-mode"))]
-use parachains_common::DAYS;
-#[cfg(feature = "fast-mode")]
-use parachains_common::MINUTES;
+use parachains_common::{DAYS, MINUTES};
+use polkadot_runtime_common::prod_or_fast;
 use sp_runtime::traits::IdentityLookup;
-
-#[cfg(feature = "fast-mode")]
-const TREASURY_SPENDING_PERIOD: BlockNumber = 5 * MINUTES;
-#[cfg(not(feature = "fast-mode"))]
-const TREASURY_SPENDING_PERIOD: BlockNumber = 7 * DAYS;
 
 parameter_types! {
 	pub const Burn: Permill = Permill::zero();
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 100 * UNIT;
-	pub const SpendPeriod: BlockNumber = TREASURY_SPENDING_PERIOD;
+	pub const SpendPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 5 * MINUTES);
 	pub const MaxApprovals: u32 = 100;
 	pub const TreasuryId: PalletId = PalletId(*b"py/trsry");
 	pub const PayoutPeriod: BlockNumber = 5;


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Replaced conditional compilation with the `prod_or_fast!` macro across multiple configuration files to streamline the selection of time durations based on the build mode.
- Removed redundant feature-specific imports for `DAYS` and `MINUTES`, consolidating them into a single import statement.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collective.rs</strong><dd><code>Use `prod_or_fast!` macro for motion duration configuration</code></dd></summary>
<hr>

runtime/laos/src/configs/collective.rs

<li>Replaced conditional compilation for <code>MOTION_DURATION</code> with <br><code>prod_or_fast!</code> macro.<br> <li> Removed feature-specific imports for <code>DAYS</code> and <code>MINUTES</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/763/files#diff-1765971514619f2120c1e3e6f80aff574e3e02d0cb52cb9cfd958894619641da">+3/-10</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>election_phragmen.rs</strong><dd><code>Use `prod_or_fast!` macro for election phragmen configuration</code></dd></summary>
<hr>

runtime/laos/src/configs/election_phragmen.rs

<li>Replaced conditional compilation for <code>TERM_DURATION</code> and <br><code>ELECTION_VOTING_LOCK_DURATION</code> with <code>prod_or_fast!</code> macro.<br> <li> Removed feature-specific imports for <code>DAYS</code> and <code>MINUTES</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/763/files#diff-4c3c0cd98ab5e5f679d0499216562bbbe6dc5638e76d05b9543343a7caff6da1">+4/-17</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>treasury.rs</strong><dd><code>Use `prod_or_fast!` macro for treasury spending period configuration</code></dd></summary>
<hr>

runtime/laos/src/configs/treasury.rs

<li>Replaced conditional compilation for <code>TREASURY_SPENDING_PERIOD</code> with <br><code>prod_or_fast!</code> macro.<br> <li> Removed feature-specific imports for <code>DAYS</code> and <code>MINUTES</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/763/files#diff-094b4a74f7e7a446c70dd2ca710d6a7c87a1c46369ec9a8125621479e247219a">+3/-10</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

