### PR TITLE
Update Rust Toolchain to 1.77 and Code Enhancements

### DIFF
--- a/node/src/chain_spec/laos.rs
+++ b/node/src/chain_spec/laos.rs
@@ -147,5 +147,5 @@ fn create_test_genesis_config() -> serde_json::Value {
 		},
 		..Default::default()
 	};
-	serde_json::to_value(&config).expect("Could not build genesis config.")
+	serde_json::to_value(config).expect("Could not build genesis config.")
 }

--- a/pallets/precompiles-benchmark/src/precompiles/vesting/benchmarking.rs
+++ b/pallets/precompiles-benchmark/src/precompiles/vesting/benchmarking.rs
@@ -132,7 +132,6 @@ type BalanceOf<Runtime> = <<Runtime as pallet_vesting::Config>::Currency as Curr
  *   T: Config + pallet_vesting: Config,
  * ```
  */
-#[allow(clippy::multiple_bound_locations)]
 #[benchmarks(
 	where
 		T: Config + pallet_vesting::Config,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.77"
 components = [ "rustfmt", "clippy", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Updated the Rust toolchain version to 1.77 in the `rust-toolchain` file.
- Simplified the `serde_json::to_value` function call in `laos.rs` by removing an unnecessary reference.
- Removed an unnecessary clippy allowance in the benchmarking file to clean up the code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>laos.rs</strong><dd><code>Simplified serde_json::to_value function call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

node/src/chain_spec/laos.rs

<li>Removed unnecessary reference in <code>serde_json::to_value</code> function call.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/768/files#diff-2ccef9e2947edd74c86ff7b5a814c38a09079830181b3f5d86bb098384e7a868">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>benchmarking.rs</strong><dd><code>Cleaned up clippy allowance in benchmarking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pallets/precompiles-benchmark/src/precompiles/vesting/benchmarking.rs

- Removed unnecessary clippy allowance for multiple bound locations.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/768/files#diff-c96290b161db484f56503993b50c485ea0f2bf389f504dd2822914522105ff90">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rust-toolchain</strong><dd><code>Updated Rust toolchain version to 1.77</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust-toolchain

- Updated Rust toolchain version to 1.77.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/768/files#diff-335ddbce02d068207f42ecdac988ee267eb014a7a1e7ffe8df7bedd66f716899">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

