### PR TITLE
Allow council to create external proposals

### DIFF
--- a/pallets/precompiles-benchmark/src/precompiles/vesting/benchmarking.rs
+++ b/pallets/precompiles-benchmark/src/precompiles/vesting/benchmarking.rs
@@ -123,15 +123,6 @@ type BalanceOf<Runtime> = <<Runtime as pallet_vesting::Config>::Currency as Curr
 	<Runtime as frame_system::Config>::AccountId,
 >>::Balance;
 
-/*
- * Allow directive added because when the macro expands, `T` has constraints in
- * multiple locations. This is what the expanded code looks like:
- * ```
- * fn _precompile_vest<T: Config>(verify: bool)
- * where
- *   T: Config + pallet_vesting: Config,
- * ```
- */
 #[benchmarks(
 	where
 		T: Config + pallet_vesting::Config,

--- a/runtime/laos/src/configs/collective.rs
+++ b/runtime/laos/src/configs/collective.rs
@@ -13,6 +13,8 @@ parameter_types! {
 	pub MaxProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
 }
 
+pub type HalfOfCouncil =
+	pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 2>;
 pub type CouncilMajority =
 	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilCollective, 1, 2>;
 pub type AllOfCouncil =

--- a/runtime/laos/src/configs/democracy.rs
+++ b/runtime/laos/src/configs/democracy.rs
@@ -1,5 +1,6 @@
 use super::collective::{
-	AllOfCouncil, AllOfTechnicalCommittee, CouncilMajority, HalfOfCouncil, TechnicalCommittee, TechnicalCommitteeMajority, TwoThirdOfCouncil
+	AllOfCouncil, AllOfTechnicalCommittee, CouncilMajority, HalfOfCouncil, TechnicalCommittee,
+	TechnicalCommitteeMajority, TwoThirdOfCouncil,
 };
 use crate::{
 	currency::UNIT, weights, AccountId, Balance, Balances, BlockNumber, OriginCaller, Preimage,

--- a/runtime/laos/src/configs/democracy.rs
+++ b/runtime/laos/src/configs/democracy.rs
@@ -1,6 +1,5 @@
 use super::collective::{
-	AllOfCouncil, AllOfTechnicalCommittee, CouncilMajority, TechnicalCommittee,
-	TechnicalCommitteeMajority, TwoThirdOfCouncil,
+	AllOfCouncil, AllOfTechnicalCommittee, CouncilMajority, HalfOfCouncil, TechnicalCommittee, TechnicalCommitteeMajority, TwoThirdOfCouncil
 };
 use crate::{
 	currency::UNIT, weights, AccountId, Balance, Balances, BlockNumber, OriginCaller, Preimage,
@@ -48,7 +47,7 @@ impl pallet_democracy::Config for Runtime {
 	type ExternalDefaultOrigin = AllOfCouncil;
 	/// A simple-majority can have the next scheduled referendum be a straight
 	/// majority-carries vote.
-	type ExternalMajorityOrigin = CouncilMajority;
+	type ExternalMajorityOrigin = HalfOfCouncil;
 	/// A straight majority of the council can decide what their next motion is.
 	type ExternalOrigin = CouncilMajority;
 	/// Majority of technical committee can have an ExternalMajority/ExternalDefault vote


### PR DESCRIPTION
This PR modifies `ExternalMajorityOrigin`, which is used by the extrinsic [`external_propose_majority`](https://github.com/paritytech/polkadot-sdk/blob/release-polkadot-v1.11.0/substrate/frame/democracy/src/lib.rs#L730). The extrinsic is called when clicking "Propose external" on the council page. `ExternalMajorityOrigin` must be changed to at least 50% of the council, as that is the threshold automatically set by the system when creating the motion.
If the motion passes, the proposal is added to the external queue with the "simple majority" voting system.

On the other hand, `ExternalOrigin` stays at more than 50% of the council. This type is used by [`external_propose`](https://github.com/paritytech/polkadot-sdk/blob/release-polkadot-v1.11.0/substrate/frame/democracy/src/lib.rs#L701) to schedule a super-majority approves referenda.
The extrinsic can be called via a normal council motion, whose threshold is customizable. Therefore, users can set the threshold to more than 50% of the council, meaning that if the motion passes and the proposal fails to be created is due to user error instead of runtime misconfiguration.

For the same reason, `ExternalDefaultOrigin` was left unchanged as well.

For more details, check the Polkadot wiki page: https://wiki.polkadot.network/docs/learn/learn-governance#adaptive-quorum-biasing

Addendum: removed the comment inside `precompile-benchmark` because of [this change](https://github.com/freeverseio/laos/pull/768/files#diff-c96290b161db484f56503993b50c485ea0f2bf389f504dd2822914522105ff90L135).