### PR TITLE
Remove Council Membership and Simplify Technical Committee Configuration

### DIFF
--- a/runtime/laos/src/benchmarks.rs
+++ b/runtime/laos/src/benchmarks.rs
@@ -36,6 +36,6 @@ frame_benchmarking::define_benchmarks!(
 	[pallet_scheduler, Scheduler]
 	[pallet_treasury, Treasury]
 	[pallet_democracy, Democracy]
-	[pallet_membership, CouncilMembership]
+	[pallet_membership, TechnicalCommitteeMembership]
 	// TODO pallet_xcm?
 );

--- a/runtime/laos/src/configs/collective.rs
+++ b/runtime/laos/src/configs/collective.rs
@@ -1,5 +1,5 @@
 use crate::{weights, AccountId, BlockNumber, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin};
-use frame_support::{pallet_prelude::Weight, parameter_types, traits::EitherOfDiverse};
+use frame_support::{pallet_prelude::Weight, parameter_types};
 use frame_system::EnsureRoot;
 use laos_primitives::RuntimeBlockWeights;
 use parachains_common::{DAYS, MINUTES};
@@ -50,7 +50,7 @@ impl pallet_collective::Config<TechnicalCommittee> for Runtime {
 	type Proposal = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
-	// the root or a turnout of 50%+1 of the council can select the technical committee
-	type SetMembersOrigin = EitherOfDiverse<EnsureRoot<AccountId>, CouncilMajority>;
+	// the root can select the technical committee
+	type SetMembersOrigin = EnsureRoot<AccountId>;
 	type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
 }

--- a/runtime/laos/src/configs/membership.rs
+++ b/runtime/laos/src/configs/membership.rs
@@ -1,23 +1,9 @@
 use frame_support::traits::EitherOfDiverse;
 use frame_system::EnsureRoot;
 
-use crate::{weights, AccountId, Council, Runtime, RuntimeEvent, TechnicalCommittee};
+use crate::{weights, AccountId, Runtime, RuntimeEvent, TechnicalCommittee};
 
 use super::collective::CouncilMajority;
-
-type CouncilMembership = pallet_membership::Instance1;
-impl pallet_membership::Config<CouncilMembership> for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type AddOrigin = EnsureRoot<AccountId>;
-	type RemoveOrigin = EnsureRoot<AccountId>;
-	type SwapOrigin = EnsureRoot<AccountId>;
-	type ResetOrigin = EnsureRoot<AccountId>;
-	type PrimeOrigin = EnsureRoot<AccountId>;
-	type MembershipInitialized = Council;
-	type MembershipChanged = Council;
-	type MaxMembers = super::collective::MaxMembers;
-	type WeightInfo = weights::pallet_membership::WeightInfo<Runtime>;
-}
 
 type TechnicalCommitteeMembership = pallet_membership::Instance2;
 impl pallet_membership::Config<TechnicalCommitteeMembership> for Runtime {

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -127,6 +127,7 @@ construct_runtime!(
 		XcmpQueue: cumulus_pallet_xcmp_queue = 30,
 		PolkadotXcm: pallet_xcm = 31,
 		CumulusXcm: cumulus_pallet_xcm = 32,
+		// TODO put the name of the remove pallet as placeholder = 33,
 		MessageQueue: pallet_message_queue = 34,
 
 		// Governance
@@ -137,8 +138,7 @@ construct_runtime!(
 		TechnicalCommittee: pallet_collective::<Instance2> = 44,
 		Scheduler: pallet_scheduler = 45,
 		Democracy: pallet_democracy = 46,
-		CouncilMembership: pallet_membership::<Instance1> = 47,
-		TechnicalCommitteeMembership: pallet_membership::<Instance2> = 48,
+		TechnicalCommitteeMembership: pallet_membership::<Instance2> = 47,
 
 		// Frontier
 		Ethereum: pallet_ethereum = 50,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Simplified the process for setting Technical Committee members by requiring only root origin, removing the council's ability to set members.
- Removed the configuration and runtime construction related to Council membership, streamlining the governance structure.
- Adjusted the runtime indices to reflect the removal of CouncilMembership.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collective.rs</strong><dd><code>Simplified Technical Committee membership origin to root only</code></dd></summary>
<hr>

runtime/laos/src/configs/collective.rs

<li>Removed <code>EitherOfDiverse</code> trait import.<br> <li> Changed <code>SetMembersOrigin</code> to use only <code>EnsureRoot<AccountId></code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/783/files#diff-1765971514619f2120c1e3e6f80aff574e3e02d0cb52cb9cfd958894619641da">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>membership.rs</strong><dd><code>Removed Council membership configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/membership.rs

<li>Removed <code>CouncilMembership</code> configuration.<br> <li> Updated imports to remove <code>Council</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/783/files#diff-d8e62ae0693df35f54eda6d900aed5445ae82c68c12546220838b2fdf0feb25a">+1/-15</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Updated runtime construction by removing CouncilMembership</code></dd></summary>
<hr>

runtime/laos/src/lib.rs

<li>Removed <code>CouncilMembership</code> from runtime construction.<br> <li> Adjusted indices for <code>TechnicalCommitteeMembership</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/783/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

