### PR TITLE
Enhance consensus hook and relay chain configuration in cumulus parachain system

### DIFF
--- a/runtime/laos/src/configs/cumulus_parachain_system.rs
+++ b/runtime/laos/src/configs/cumulus_parachain_system.rs
@@ -38,11 +38,28 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
-	type ConsensusHook = cumulus_pallet_parachain_system::ExpectParentIncluded;
+	type CheckAssociatedRelayNumber =
+		cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
+	type ConsensusHook = ConsensusHook;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
 	type WeightInfo = weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
 }
+
+/// Maximum number of blocks simultaneously accepted by the Runtime, not yet included
+/// into the relay chain.
+const UNINCLUDED_SEGMENT_CAPACITY: u32 = 1;
+/// How many parachain blocks are processed by the relay chain per parent. Limits the
+/// number of blocks authored per slot.
+const BLOCK_PROCESSING_VELOCITY: u32 = 1;
+/// Relay chain slot duration, in milliseconds.
+const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
+
+type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
+	Runtime,
+	RELAY_CHAIN_SLOT_DURATION_MILLIS,
+	BLOCK_PROCESSING_VELOCITY,
+	UNINCLUDED_SEGMENT_CAPACITY,
+>;
 
 // This struct is never instantiated, it is only used for the `CheckInherents` implementation.
 // It will be deprecated soon:

--- a/runtime/laos/src/configs/cumulus_parachain_system.rs
+++ b/runtime/laos/src/configs/cumulus_parachain_system.rs
@@ -38,8 +38,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber =
-		cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 	type ConsensusHook = ConsensusHook;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
 	type WeightInfo = weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the consensus hook by changing its implementation to `FixedVelocityConsensusHook`.
- Introduced new constants to configure relay chain parameters such as slot duration and block processing velocity.
- Improved the configuration of the cumulus parachain system for better performance and reliability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cumulus_parachain_system.rs</strong><dd><code>Enhance consensus hook with fixed velocity configuration</code>&nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/cumulus_parachain_system.rs

<li>Changed the <code>ConsensusHook</code> type to a new implementation.<br> <li> Introduced constants for relay chain configuration.<br> <li> Added a new type <code>ConsensusHook</code> with specific parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/786/files#diff-7c3123d213dd4de6d096ac5e3beddd348c6a7636f540c8d1960928576d269e81">+17/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

