### PR TITLE
Include AssetHub in zombienet

### DIFF
--- a/zombienet/README.md
+++ b/zombienet/README.md
@@ -1,5 +1,7 @@
 # Zombienet
 
+TODO update me (how to build `polkadot-parachain` and spawn zombienet with the proper file if you want assethub)
+
 The [Zombienet](https://github.com/paritytech/zombienet) configuration is located in the `native.toml` file.
 
 Zombienet uses environment variables in the `native.toml` configuration file for easy customization. You can define these variables in your shell before running the commands. 

--- a/zombienet/README.md
+++ b/zombienet/README.md
@@ -1,37 +1,54 @@
 # Zombienet
+The [Zombienet](https://github.com/paritytech/zombienet) configurations are located under the `zombienet` folder.
 
-TODO update me (how to build `polkadot-parachain` and spawn zombienet with the proper file if you want assethub)
-
-The [Zombienet](https://github.com/paritytech/zombienet) configuration is located in the `native.toml` file.
-
-Zombienet uses environment variables in the `native.toml` configuration file for easy customization. You can define these variables in your shell before running the commands. 
+Zombienet uses environment variables in the configuration files for easy customization. You can define these variables in your shell before running the commands.
 
 ## How to
 
-**Download Zombienet**
-
-Download the Zombienet binary from the [releases page](https://github.com/paritytech/zombienet/releases)
-
-For example:
+### Download Zombienet
+Download the Zombienet binary from the [releases page](https://github.com/paritytech/zombienet/releases). For example:
 
 ```sh
 $ wget -O zombienet https://github.com/paritytech/zombienet/releases/download/v1.3.106/zombienet-linux-x64 && chmod +x zombienet
 ```
 
-**Start Zombienet**
-
-This will launch a local Rococo relay chain with one parachain: Laos.
-
-Before running the commands, set up the environment variables `ZOMBIENET_RELAYCHAIN_COMMAND` and `ZOMBIENET_LAOS_COMMAND`, `ZOMBIENET_ASTAR_COMMAND` in your shell. 
-
-For example:
+### Run Zombienet
+Before spawning zombienet, set up the environment variables `ZOMBIENET_RELAYCHAIN_COMMAND` and `ZOMBIENET_LAOS_COMMAND` in a terminal session or in your shell configuration file (e.g. `~/.bashrc`, `~/.zsh.rc`):
 
 ```sh
-export ZOMBIENET_RELAYCHAIN_COMMAND=<path-to-relay-chain-executable>
-export ZOMBIENET_LAOS_COMMAND=<path-to-parachain-executable>
-export ZOMBIENET_ASTAR_COMMAND=<path-to-astar-executable>
+export ZOMBIENET_RELAYCHAIN_COMMAND=<path-to-polkadot-executable>
+export ZOMBIENET_LAOS_COMMAND=<path-to-laos-executable>
 ```
 
+To run the relay chain locally, you need the `polkadot` binary. Either download it from the [polkadot-sdk releases tab](https://github.com/paritytech/polkadot-sdk/releases), or clone the [polkadot-sdk repo](https://github.com/paritytech/polkadot-sdk/) and compile the project with the command:
 ```sh
-$ ./zombienet spawn native.toml
+cargo build --release --locked
 ```
+
+#### Parchain-only
+This a local Rococo relay chain with one parachain: Laos.
+
+```sh
+$ zombienet spawn zombienet/native.toml
+```
+
+#### Parachain and AssetHub
+Use this configuration in case you need to test XCM. This a local Rococo relay chain with two parachains: Laos and AssetHub.
+
+To run AssetHub locally, you need the `polkadot-parachain` binary. Either download it from the [polkadot-sdk releases tab](https://github.com/paritytech/polkadot-sdk/releases), or clone the [polkadot-sdk repo](https://github.com/paritytech/polkadot-sdk/) and compile the project with the command:
+```sh
+cargo build --release --locked -p polkadot-parachain-bin --bin polkadot-parachain
+```
+
+After that, declare a new environment variable, either in a terminal session or in your shell configuration file (e.g. `~/.bashrc`, `~/.zsh.rc`):
+```sh
+export ZOMBIENET_ASSETHUB_COMMAND=<path-to-polkadot-parachain-executable>
+```
+
+You're now ready to spawn the proper configuration of zombienet:
+```sh
+$ zombienet spawn zombienet/xcm-native.toml
+```
+
+#### CLI options
+Please, refer to: https://paritytech.github.io/zombienet/cli/index.html.

--- a/zombienet/xcm-native.toml
+++ b/zombienet/xcm-native.toml
@@ -37,3 +37,15 @@ force_decorator = "generic-evm"
   ws_port = 10001
   command = "{{ZOMBIENET_LAOS_COMMAND}}"
   validator = true
+
+[[parachains]]
+id = 2000
+cumulus_based = true
+chain = "asset-hub-rococo-local"
+
+  [[parachains.collators]]
+  name = "asset-hub"
+  validator = true
+  ws_port = 9950
+  command = "{{ZOMBIENET_ASSETHUB_COMMAND}}"
+  args = ["--log=xcm=trace,pallet-assets=trace"]


### PR DESCRIPTION
- new zombienet config file created: I decided to create a new file so if one does not need to test XCM functionalities, they can spawn `native.toml` as usual
- README updated
- after you spawn the network with zombienet, you should see "Assets" and "NFTs" under the "Network" tab of AssetHub in polkadot.js:
![image](https://github.com/user-attachments/assets/209b0ee1-0f3d-47ca-bc0b-11e8b58ceecf)