### PR TITLE
Remove "staging-" prefix from XCM and parachain info modules and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/pol
 cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
 cumulus-primitives-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
 cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
-staging-parachain-info = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
+parachain-info = { package = "staging-parachain-info", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
 parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
 
 # (native)
@@ -204,9 +204,9 @@ polkadot-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch 
 # XCM
 # (wasm)
 cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
-staging-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
-staging-xcm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
-staging-xcm-executor = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0", default-features = false }
 
 # (native)
 polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.11.0" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -54,7 +54,7 @@ substrate-prometheus-endpoint = { workspace = true }
 polkadot-cli = { workspace = true, features = ["rococo-native"] }
 polkadot-service = { workspace = true, features = ["rococo-native"] }
 polkadot-primitives = { workspace = true }
-staging-xcm = { workspace = true }
+xcm = { workspace = true }
 laos-primitives = { workspace = true }
 
 # Cumulus

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -23,7 +23,7 @@ pub mod laos;
 mod predefined_accounts;
 
 /// The default XCM version to set in genesis config.
-const SAFE_XCM_VERSION: u32 = staging_xcm::prelude::XCM_VERSION;
+const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 /// Helper function to generate a crypto pair from seed
 fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {

--- a/runtime/laos/Cargo.toml
+++ b/runtime/laos/Cargo.toml
@@ -77,9 +77,9 @@ pallet-precompiles-benchmark = { workspace = true }
 pallet-xcm = { workspace = true }
 polkadot-runtime-common = { workspace = true }
 polkadot-parachain-primitives = { workspace = true }
-staging-xcm = { workspace = true }
-staging-xcm-builder = { workspace = true }
-staging-xcm-executor = { workspace = true }
+xcm = { workspace = true }
+xcm-builder = { workspace = true }
+xcm-executor = { workspace = true }
 
 # Cumulus
 cumulus-pallet-aura-ext = { workspace = true }
@@ -90,7 +90,7 @@ cumulus-pallet-xcmp-queue = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 cumulus-primitives-timestamp = { workspace = true }
 cumulus-primitives-utility = { workspace = true }
-staging-parachain-info = { workspace = true }
+parachain-info = { workspace = true }
 parachains-common = { workspace = true }
 
 # Frontier
@@ -168,7 +168,7 @@ std = [
 	"pallet-precompiles-benchmark/std",
 	"pallet-transaction-payment/std",
 	"pallet-xcm/std",
-	"staging-parachain-info/std",
+	"parachain-info/std",
 	"polkadot-parachain-primitives/std",
 	"polkadot-runtime-common/std",
 	"sp-api/std",
@@ -185,9 +185,9 @@ std = [
 	"sp-version/std",
 	"sp-weights/std",
 	"sp-genesis-builder/std",
-	"staging-xcm-builder/std",
-	"staging-xcm-executor/std",
-	"staging-xcm/std",
+	"xcm-builder/std",
+	"xcm-executor/std",
+	"xcm/std",
 	"substrate-wasm-builder",
 	# Frontier
 	"fp-evm/std",
@@ -237,7 +237,7 @@ runtime-benchmarks = [
 	"pallet-elections-phragmen/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	"staging-xcm-builder/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
 	"cumulus-pallet-session-benchmarking/runtime-benchmarks",
 	"cumulus-pallet-xcmp-queue/runtime-benchmarks",
 	"pallet-message-queue/runtime-benchmarks",
@@ -247,7 +247,7 @@ runtime-benchmarks = [
 	"pallet-sudo/runtime-benchmarks",
 	"polkadot-parachain-primitives/runtime-benchmarks",
 	"polkadot-runtime-common/runtime-benchmarks",
-	"staging-xcm-executor/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
 	"pallet-asset-metadata-extender/runtime-benchmarks",
 	"pallet-vesting/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
@@ -285,7 +285,7 @@ try-runtime = [
 	"pallet-treasury/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"pallet-xcm/try-runtime",
-	"staging-parachain-info/try-runtime",
+	"parachain-info/try-runtime",
 	"pallet-evm/try-runtime",
 	"pallet-evm-chain-id/try-runtime",
 	"pallet-ethereum/try-runtime",

--- a/runtime/laos/src/configs/mod.rs
+++ b/runtime/laos/src/configs/mod.rs
@@ -57,4 +57,4 @@ parameter_types! {
 
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 impl pallet_evm_chain_id::Config for Runtime {}
-impl staging_parachain_info::Config for Runtime {}
+impl parachain_info::Config for Runtime {}

--- a/runtime/laos/src/configs/xcm_config.rs
+++ b/runtime/laos/src/configs/xcm_config.rs
@@ -28,8 +28,8 @@ use frame_system::{EnsureRoot, RawOrigin as SystemRawOrigin};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::TryConvert;
-use staging_xcm::latest::prelude::*;
-use staging_xcm_builder::{
+use xcm::latest::prelude::*;
+use xcm_builder::{
 	AccountKey20Aliases, AllowExplicitUnpaidExecutionFrom, AllowTopLevelPaidExecutionFrom,
 	DenyReserveTransferToRelayChain, DenyThenTry, EnsureXcmOrigin, FixedWeightBounds,
 	FrameTransactionalProcessor, FungibleAdapter, IsConcrete, NativeAsset, ParentIsPreset,
@@ -37,7 +37,7 @@ use staging_xcm_builder::{
 	SignedAccountKey20AsNative, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
 	UsingComponents, WithComputedOrigin,
 };
-use staging_xcm_executor::XcmExecutor;
+use xcm_executor::XcmExecutor;
 
 parameter_types! {
 	pub const RelayLocation: Location = Location::parent();
@@ -128,7 +128,7 @@ pub type Barrier = TrailingSetTopicAsId<
 >;
 
 pub struct XcmConfig;
-impl staging_xcm_executor::Config for XcmConfig {
+impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
 	// How to withdraw and deposit an asset.
@@ -171,7 +171,7 @@ pub type LocalOriginToLocation = SignedToAccountId20<RuntimeOrigin, AccountId, R
 
 /// The means for routing XCM messages which are not for local execution into the right message
 /// queues.
-pub type XcmRouter = staging_xcm_builder::WithUniqueTopic<(
+pub type XcmRouter = xcm_builder::WithUniqueTopic<(
 	// Two routers - use UMP to communicate with the relay chain:
 	cumulus_primitives_utility::ParentAsUmp<crate::ParachainSystem, (), ()>,
 	// ..and XCMP to communicate with the sibling chains.

--- a/runtime/laos/src/configs/xcm_message_queue.rs
+++ b/runtime/laos/src/configs/xcm_message_queue.rs
@@ -23,9 +23,9 @@ impl pallet_message_queue::Config for Runtime {
 	type MessageProcessor =
 		pallet_message_queue::mock_helpers::NoopMessageProcessor<AggregateMessageOrigin>;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type MessageProcessor = staging_xcm_builder::ProcessXcmMessage<
+	type MessageProcessor = xcm_builder::ProcessXcmMessage<
 		AggregateMessageOrigin,
-		staging_xcm_executor::XcmExecutor<super::xcm_config::XcmConfig>,
+		xcm_executor::XcmExecutor<super::xcm_config::XcmConfig>,
 		crate::RuntimeCall,
 	>;
 	type Size = u32;

--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -104,7 +104,7 @@ construct_runtime!(
 		System: frame_system = 0,
 		ParachainSystem: cumulus_pallet_parachain_system = 1,
 		Timestamp: pallet_timestamp = 2,
-		ParachainInfo: staging_parachain_info = 3,
+		ParachainInfo: parachain_info = 3,
 		Sudo: pallet_sudo = 4,
 		Utility: pallet_utility = 5,
 		Multisig: pallet_multisig = 6,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated various Rust modules to replace `staging_xcm` and related modules with `xcm` and its corresponding modules.
- Changed `parachain_info` configurations to remove the "staging-" prefix.
- Updated Cargo.toml files to reflect changes in dependencies, removing the "staging-" prefix from XCM and parachain info packages.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update XCM version reference in chain spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

node/src/chain_spec/mod.rs

<li>Updated <code>SAFE_XCM_VERSION</code> to use <code>xcm::prelude::XCM_VERSION</code> instead of <br><code>staging_xcm::prelude::XCM_VERSION</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/803/files#diff-d0ab461d3f1322691c297bdf74c56e023de548c8555915ed6b60b0a792129341">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update parachain info configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/mod.rs

- Changed implementation of `parachain_info::Config` for `Runtime`.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/803/files#diff-450b756d1af9090dd62cc432c3c21a1a4f655d52ee8b477c3d81e1038434d68b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>xcm_config.rs</strong><dd><code>Replace staging XCM with XCM in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/xcm_config.rs

<li>Replaced <code>staging_xcm</code> and <code>staging_xcm_builder</code> with <code>xcm</code> and <code>xcm_builder</code>.<br> <li> Updated <code>XcmExecutor</code> implementation to use <code>xcm_executor</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/803/files#diff-7be85ebadbdf1d1e426a2b4f3e4f1d6b496df8603fa762c7e0efcceb40533a48">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>xcm_message_queue.rs</strong><dd><code>Update XCM message queue configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/xcm_message_queue.rs

<li>Updated <code>MessageProcessor</code> to use <code>xcm_builder::ProcessXcmMessage</code>.<br> <li> Changed <code>XcmExecutor</code> to use <code>xcm_executor</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/803/files#diff-5b3d5456abe65dc503924039c805175a1d6ed1a1ac22da0180ca0dfde4307eab">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Update parachain info in runtime construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/lib.rs

<li>Updated <code>ParachainInfo</code> to use <code>parachain_info</code> instead of <br><code>staging_parachain_info</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/803/files#diff-003c87018a12c01c5266d5e1f3aba274f64cc6651fdb6b34abb88a6d1a10d073">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update Cargo dependencies for XCM and parachain info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<li>Replaced <code>staging-parachain-info</code> with <code>parachain-info</code>.<br> <li> Updated XCM related dependencies to remove "staging-" prefix.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/803/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update XCM dependency in node Cargo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

node/Cargo.toml

- Changed `staging-xcm` to `xcm`.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/803/files#diff-5dc0537169cb810865347de9185dae9ac7d231b7b5eb18eae2086c578dda133e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update runtime dependencies for XCM and parachain info</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/Cargo.toml

<li>Updated XCM and parachain info dependencies to remove "staging-" <br>prefix.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/803/files#diff-9b329717b96857f6884c9b9a32fc471267d6f9c0acc1a3b0e4758d73de6d34e5">+11/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information