### PR TITLE
Add Try Runtime for Laos in GitHub Actions Workflow


### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,6 @@ jobs:
       - name: Try Runtime for Laos Sigma
         run: |
           RUST_LOG=try-runtime ./try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks=all live --uri ws://159.223.241.51:9944
-      - name: Try Runtime for Laos Laos
+      - name: Try Runtime for Laos
         run: |
           RUST_LOG=try-runtime ./try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks=all live --uri wss://rpc.laos.laosfoundation.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,3 +123,6 @@ jobs:
       - name: Try Runtime for Laos Sigma
         run: |
           RUST_LOG=try-runtime ./try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks=all live --uri ws://159.223.241.51:9944
+      - name: Try Runtime for Laos Laos
+        run: |
+          RUST_LOG=try-runtime ./try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks=all live --uri wss://rpc.laos.laosfoundation.io


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the GitHub Actions workflow by adding a new step to run Try Runtime for the Laos blockchain.
- Configured the Try Runtime command to connect to the Laos foundation's WebSocket endpoint.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Add Try Runtime step for Laos in GitHub Actions workflow</code>&nbsp; </dd></summary>
<hr>

.github/workflows/build.yml

<li>Added a new step to the GitHub Actions workflow for running Try <br>Runtime on Laos.<br> <li> Configured the Try Runtime command to connect to a new WebSocket URI <br>for Laos.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/809/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information