### PR TITLE
Add tests for Mercury sovereign account IDs


### DIFF
--- a/xcm-simulator/src/tests/mod.rs
+++ b/xcm-simulator/src/tests/mod.rs
@@ -27,6 +27,19 @@ fn remote_account_ids_work() {
 }
 
 #[test]
+fn test_child_account_id() {
+	let mercury_para_id = 4023;
+	assert_eq!(
+		child_account_id(mercury_para_id).to_ss58check(),
+		"5Ec4AhPPwDMAVDP2wYGzGyJuq1wHrKeDVJ2znDdyj9Zb7x7t"
+	);
+	assert_eq!(
+		sibling_account_id(mercury_para_id).to_ss58check(),
+		"5Eg2fntD1wY4cp7BVYE5Pcej5VcbZjhKYwgS3BAUbsb9ykJ9"
+	);
+}
+
+#[test]
 fn dmp() {
 	MockNet::reset();
 

--- a/xcm-simulator/src/tests/mod.rs
+++ b/xcm-simulator/src/tests/mod.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use frame_support::{assert_ok, traits::fungibles::roles::Inspect, weights::Weight};
 use parity_scale_codec::Encode;
+use sp_core::crypto::Ss58Codec;
 use xcm::latest::QueryResponseInfo;
 use xcm_simulator::TestExt;
 
@@ -27,12 +28,14 @@ fn remote_account_ids_work() {
 }
 
 #[test]
-fn test_child_account_id() {
+fn check_sovereign_accounts() {
 	let mercury_para_id = 4023;
+	// mercury parachain on ralay chain
 	assert_eq!(
 		child_account_id(mercury_para_id).to_ss58check(),
 		"5Ec4AhPPwDMAVDP2wYGzGyJuq1wHrKeDVJ2znDdyj9Zb7x7t"
 	);
+	// mercury parachain on sibling chains
 	assert_eq!(
 		sibling_account_id(mercury_para_id).to_ss58check(),
 		"5Eg2fntD1wY4cp7BVYE5Pcej5VcbZjhKYwgS3BAUbsb9ykJ9"


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Added a new test function `test_child_account_id` to verify the correct SS58 check addresses for `child_account_id` and `sibling_account_id`.
- Ensures that the account ID generation logic for child and sibling accounts is functioning as expected.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add test for child and sibling account IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

xcm-simulator/src/tests/mod.rs

<li>Added a new test function <code>test_child_account_id</code>.<br> <li> Verified <code>child_account_id</code> and <code>sibling_account_id</code> with specific SS58 <br>check addresses.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/816/files#diff-980f82b95ef00d258bfff1b76d838745b95b804506292e62727b19e185d91e2a">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information