### PR TITLE
Enable Root Account to Spend Treasury Funds


### DIFF
--- a/runtime/laos/src/configs/treasury.rs
+++ b/runtime/laos/src/configs/treasury.rs
@@ -54,7 +54,7 @@ impl pallet_treasury::Config for Runtime {
 	type ProposalBondMinimum = ProposalBondMinimum;
 	type RejectOrigin = RejectOrigin;
 	type RuntimeEvent = RuntimeEvent;
-	type SpendFunds = ();
+	type SpendFunds = EnsureRoot<AccountId>;
 	type SpendPeriod = SpendPeriod;
 	// Disabled, no spending allowed.
 	#[cfg(not(feature = "runtime-benchmarks"))]


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the Treasury configuration to allow the root account to spend funds.
- Changed the `SpendFunds` type to `EnsureRoot<AccountId>`, enabling root-level access for fund spending.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>treasury.rs</strong><dd><code>Allow root to spend funds from Treasury</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/treasury.rs

<li>Changed the <code>SpendFunds</code> configuration to use <code>EnsureRoot<AccountId></code>.<br> <li> This allows the root to spend funds from the Treasury.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/850/files#diff-094b4a74f7e7a446c70dd2ca710d6a7c87a1c46369ec9a8125621479e247219a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information