### PR TITLE
Enhance ManagerOrigin to Include Council Majority


### DIFF
--- a/runtime/laos/src/configs/preimage.rs
+++ b/runtime/laos/src/configs/preimage.rs
@@ -15,12 +15,12 @@
 // along with LAOS.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	currency::calculate_deposit, weights, AccountId, Balance, Balances, Runtime, RuntimeEvent,
-	RuntimeHoldReason,
+	configs::collective::CouncilMajority, currency::calculate_deposit, weights, AccountId, Balance,
+	Balances, Runtime, RuntimeEvent, RuntimeHoldReason,
 };
 use frame_support::{
 	parameter_types,
-	traits::{fungible::HoldConsideration, LinearStoragePrice},
+	traits::{fungible::HoldConsideration, EitherOfDiverse, LinearStoragePrice},
 };
 use frame_system::EnsureRoot;
 
@@ -33,7 +33,7 @@ parameter_types! {
 
 impl pallet_preimage::Config for Runtime {
 	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
+	type ManagerOrigin = EitherOfDiverse<EnsureRoot<AccountId>, CouncilMajority>;
 	type RuntimeEvent = RuntimeEvent;
 	type Consideration = HoldConsideration<
 		AccountId,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `ManagerOrigin` configuration to allow either root access or a majority of the council to manage preimages.
- Introduced `CouncilMajority` as a new import and utilized it in the `ManagerOrigin` type.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>preimage.rs</strong><dd><code>Enhance ManagerOrigin with CouncilMajority support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/preimage.rs

<li>Added <code>CouncilMajority</code> to the imports.<br> <li> Replaced <code>EnsureRoot<AccountId></code> with <code>EitherOfDiverse<EnsureRoot<AccountId>, CouncilMajority></code> for <br><code>ManagerOrigin</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/851/files#diff-c6801561499be1a052a7dda74f9a3b9018f28f9cda3fde75568ebedb0a014f99">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information