### PR TITLE
Redirect Kicked Members' Balance to Treasury in Election Configuration


### DIFF
--- a/runtime/laos/src/configs/election_phragmen.rs
+++ b/runtime/laos/src/configs/election_phragmen.rs
@@ -43,6 +43,6 @@ impl pallet_elections_phragmen::Config for Runtime {
 	type TermDuration = TermDuration;
 	type VotingBondBase = VotingBondBase;
 	type VotingBondFactor = VotingBondFactor;
-	type KickedMember = ();
+	type KickedMember = Treasury;
 	type WeightInfo = weights::pallet_elections_phragmen::WeightInfo<Runtime>;
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `KickedMember` type in the election configuration from an empty tuple to `Treasury`, which likely redirects the balance of kicked members to the treasury.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>election_phragmen.rs</strong><dd><code>Update `KickedMember` type to `Treasury` in election configuration</code></dd></summary>
<hr>

runtime/laos/src/configs/election_phragmen.rs

<li>Changed the type of <code>KickedMember</code> from an empty tuple to <code>Treasury</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/854/files#diff-4c3c0cd98ab5e5f679d0499216562bbbe6dc5638e76d05b9543343a7caff6da1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information