### PR TITLE
Only teleport native asset

### DIFF
--- a/runtime/laos/src/configs/xcm_config.rs
+++ b/runtime/laos/src/configs/xcm_config.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	types::ToAuthor, AccountId, AllPalletsWithSystem, Balances, ParachainInfo, PolkadotXcm,
-	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
+	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Vec
 };
 use core::marker::PhantomData;
 use frame_support::{

--- a/runtime/laos/src/configs/xcm_config.rs
+++ b/runtime/laos/src/configs/xcm_config.rs
@@ -247,8 +247,8 @@ impl pallet_xcm::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	// This filter wheter an origin may teleport out different assets.
 	type XcmTeleportFilter = OnlyTeleportNative;
-	// Allows all reserve asset transfers.
-	type XcmReserveTransferFilter = Everything;
+	// Deny all reserve asset transfers.
+	type XcmReserveTransferFilter = Nothing;
 	// Calculates the weight of XCM messages.
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 	type UniversalLocation = UniversalLocation;

--- a/runtime/laos/src/configs/xcm_config.rs
+++ b/runtime/laos/src/configs/xcm_config.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	types::ToAuthor, AccountId, AllPalletsWithSystem, Balances, ParachainInfo, PolkadotXcm,
-	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Vec
+	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Vec,
 };
 use core::marker::PhantomData;
 use frame_support::{

--- a/runtime/laos/src/configs/xcm_config.rs
+++ b/runtime/laos/src/configs/xcm_config.rs
@@ -303,6 +303,10 @@ where
 mod tests {
 	use super::*;
 
+	parameter_types! {
+		pub SomeLocation: Location = Location::new(1, [Junction::Parachain(123)] );
+	}
+
 	#[test]
 	fn check_checking_account() {
 		assert_eq!(
@@ -324,7 +328,7 @@ mod tests {
 	fn only_teleport_native_contains_not_all_assets_are_native() {
 		let assets: Vec<Asset> = vec![
 			(HereLocation::get(), Fungible(1_000)).into(),
-			(RelayLocation::get(), Fungible(1_000)).into(),
+			(SomeLocation::get(), Fungible(1_000)).into(),
 		];
 
 		// The first parameter passed to contains may be any location as it's not used by the

--- a/runtime/laos/src/configs/xcm_config.rs
+++ b/runtime/laos/src/configs/xcm_config.rs
@@ -221,17 +221,17 @@ pub type XcmRouter = xcm_builder::WithUniqueTopic<(
 
 //Filter all teleports that aren't the native asset
 pub struct OnlyTeleportNative;
-impl Contains<(Location, Vec<Asset>)> for OnlyTeleportNative{
-    fn contains(t:&(Location, Vec<Asset>)) -> bool{
-        t.1.iter().all(|asset|{
-            log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
-            if let Asset{ id: asset_id, fun: Fungible(_)}= asset{
-                asset_id.0 == HereLocation::get()
-            } else{
-                false
-            }
-        })
-    }
+impl Contains<(Location, Vec<Asset>)> for OnlyTeleportNative {
+	fn contains(t: &(Location, Vec<Asset>)) -> bool {
+		t.1.iter().all(|asset| {
+			log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
+			if let Asset { id: asset_id, fun: Fungible(_) } = asset {
+				asset_id.0 == HereLocation::get()
+			} else {
+				false
+			}
+		})
+	}
 }
 
 impl pallet_xcm::Config for Runtime {
@@ -243,7 +243,7 @@ impl pallet_xcm::Config for Runtime {
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmExecuteFilter = Nothing;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type XcmTeleportFilter =OnlyTeleportNative;
+	type XcmTeleportFilter = OnlyTeleportNative;
 	// Allows all reserve asset transfers.
 	type XcmReserveTransferFilter = Everything;
 	// Calculates the weight of XCM messages.

--- a/xcm-simulator/src/laosish/configs/xcm_config.rs
+++ b/xcm-simulator/src/laosish/configs/xcm_config.rs
@@ -184,6 +184,21 @@ impl xcm_executor::Config for XcmConfig {
 pub type LocalOriginToLocation = SignedToAccountId20<RuntimeOrigin, AccountId, RelayNetwork>;
 pub type XcmRouter = EnsureDecodableXcm<crate::ParachainXcmRouter<MsgQueue>>;
 
+//Filter all teleports that aren't the native asset
+pub struct OnlyTeleportNative;
+impl Contains<(Location, Vec<Asset>)> for OnlyTeleportNative{
+    fn contains(t:&(Location, Vec<Asset>)) -> bool{
+        t.1.iter().all(|asset|{
+            log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
+            if let Asset{ id: asset_id, fun: Fungible(_)}= asset{
+                asset_id.0 == HereLocation::get()
+            } else{
+                false
+            }
+        })
+    }
+}
+
 impl pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type SendXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
@@ -191,9 +206,7 @@ impl pallet_xcm::Config for Runtime {
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmExecuteFilter = Nothing;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	// it is safe to have `Everything` as `IsTeleporter` performs an additional check on the
-	// parachain
-	type XcmTeleportFilter = Everything;
+	type XcmTeleportFilter = OnlyTeleportNative;
 	type XcmReserveTransferFilter = Everything;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 	type UniversalLocation = UniversalLocation;

--- a/xcm-simulator/src/laosish/configs/xcm_config.rs
+++ b/xcm-simulator/src/laosish/configs/xcm_config.rs
@@ -207,7 +207,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmExecuteFilter = Nothing;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = OnlyTeleportNative;
-	type XcmReserveTransferFilter = Everything;
+	type XcmReserveTransferFilter = Nothing;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 	type UniversalLocation = UniversalLocation;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/xcm-simulator/src/laosish/configs/xcm_config.rs
+++ b/xcm-simulator/src/laosish/configs/xcm_config.rs
@@ -186,17 +186,17 @@ pub type XcmRouter = EnsureDecodableXcm<crate::ParachainXcmRouter<MsgQueue>>;
 
 //Filter all teleports that aren't the native asset
 pub struct OnlyTeleportNative;
-impl Contains<(Location, Vec<Asset>)> for OnlyTeleportNative{
-    fn contains(t:&(Location, Vec<Asset>)) -> bool{
-        t.1.iter().all(|asset|{
-            log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
-            if let Asset{ id: asset_id, fun: Fungible(_)}= asset{
-                asset_id.0 == HereLocation::get()
-            } else{
-                false
-            }
-        })
-    }
+impl Contains<(Location, Vec<Asset>)> for OnlyTeleportNative {
+	fn contains(t: &(Location, Vec<Asset>)) -> bool {
+		t.1.iter().all(|asset| {
+			log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
+			if let Asset { id: asset_id, fun: Fungible(_) } = asset {
+				asset_id.0 == HereLocation::get()
+			} else {
+				false
+			}
+		})
+	}
 }
 
 impl pallet_xcm::Config for Runtime {

--- a/xcm-simulator/src/laosish/configs/xcm_config.rs
+++ b/xcm-simulator/src/laosish/configs/xcm_config.rs
@@ -41,7 +41,6 @@ use xcm_executor::XcmExecutor;
 use xcm_simulator::AssetFilter;
 
 parameter_types! {
-	pub const RelayLocation: Location = Location::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	// For the real deployment, it is recommended to set `RelayNetwork` according to the relay chain


### PR DESCRIPTION
Set our XCM teleport filter to only allow teleporting out our native asset.