### PR TITLE
Delete VotingLockPeriod in pallet elections phragment

### DIFF
--- a/runtime/laos/src/configs/election_phragmen.rs
+++ b/runtime/laos/src/configs/election_phragmen.rs
@@ -9,7 +9,6 @@ use polkadot_runtime_common::{prod_or_fast, CurrencyToVote};
 parameter_types! {
 	pub const CandidacyBond: Balance = 1000 * UNIT;
 	pub TermDuration: BlockNumber = prod_or_fast!(28 * DAYS, 10 * MINUTES);
-	pub VotingLockPeriod: BlockNumber = prod_or_fast!(28 * DAYS, 10 * MINUTES);
 	pub const DesiredMembers: u32 = 7;
 	pub const DesiredRunnersUp: u32 = 20;
 	pub const MaxCandidates: u32 = 30;


### PR DESCRIPTION
As described in [the docs](https://paritytech.github.io/polkadot-sdk/master/pallet_elections_phragmen/index.html#voting), a voter gets its bond back by calling the ``remove_voter`` extrinsic, not when a specified amount of time has passed. Then we don't need to define the type ``VotingLockPeriod``