### PR TITLE
Reduce Maximum Vesting Schedules and Simplify Migrations


### DIFF
--- a/runtime/laos/src/configs/vesting.rs
+++ b/runtime/laos/src/configs/vesting.rs
@@ -25,7 +25,7 @@ parameter_types! {
 }
 
 impl pallet_vesting::Config for Runtime {
-	const MAX_VESTING_SCHEDULES: u32 = 56;
+	const MAX_VESTING_SCHEDULES: u32 = 28;
 
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;

--- a/runtime/laos/src/migrations/mod.rs
+++ b/runtime/laos/src/migrations/mod.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with LAOS.  If not, see <http://www.gnu.org/licenses/>.
 
-mod async_backing;
-
 use crate::Runtime;
 
-pub type Migrations =
-	(cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>, async_backing::Migration);
+pub type Migrations = cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>;

--- a/runtime/laos/src/tests/metadata15.golden
+++ b/runtime/laos/src/tests/metadata15.golden
@@ -39860,7 +39860,7 @@
               "name": "MaxVestingSchedules",
               "ty": 4,
               "value": [
-                56,
+                28,
                 0,
                 0,
                 0

--- a/runtime/laos/src/tests/mod.rs
+++ b/runtime/laos/src/tests/mod.rs
@@ -135,7 +135,7 @@ fn check_pallet_vesting_configuration() {
 		<Runtime as pallet_vesting::Config>::UnvestedFundsAllowedWithdrawReasons::get(),
 		WithdrawReasons::except(WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE)
 	);
-	assert_eq!(<Runtime as pallet_vesting::Config>::MAX_VESTING_SCHEDULES, 56);
+	assert_eq!(<Runtime as pallet_vesting::Config>::MAX_VESTING_SCHEDULES, 28);
 }
 
 #[test]


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Reduced the `MAX_VESTING_SCHEDULES` constant from 56 to 28 in the vesting configuration.
- Removed the `async_backing` module from the migration types, simplifying the migration process.
- Updated tests to reflect the new `MAX_VESTING_SCHEDULES` value.
- Adjusted metadata to align with the updated vesting schedules configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vesting.rs</strong><dd><code>Reduce maximum vesting schedules in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/vesting.rs

- Reduced `MAX_VESTING_SCHEDULES` from 56 to 28.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/868/files#diff-6c67f5e1403fa2826cc5e3e12726ef7f73ca98c69b6ade8edba8d8dceecd3cb5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Simplify migration type by removing async_backing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/migrations/mod.rs

- Removed `async_backing` module from migrations.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/868/files#diff-8d9336c1ee9f350152a5b901f6dfc2f5df703bc8a5e931f1d0d85dbe958260b6">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metadata15.golden</strong><dd><code>Update metadata for new max vesting schedules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/tests/metadata15.golden

<li>Updated metadata to reflect new <code>MAX_VESTING_SCHEDULES</code> value of 28.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/868/files#diff-217ea3c78af3728eb4e6c17162c46fbb16e05e5e669dc6a11261ba4f33fc021c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update vesting configuration test for new max schedules</code>&nbsp; &nbsp; </dd></summary>
<hr>

runtime/laos/src/tests/mod.rs

- Updated test to reflect new `MAX_VESTING_SCHEDULES` value of 28.



</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/868/files#diff-1a659c6a8b782e2864dec981a7081c08884e9457079867476a915e52c482b8fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information