### PR TITLE
Implement call filter to exclude vested transfers in runtime configuration


### DIFF
--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -186,7 +186,7 @@ mod tests {
 	}
 
 	#[test]
-	fn vested_transfer_should_be_allowed() {
+	fn vested_transfer_should_not_be_allowed() {
 		let alice = AccountId::from_str(ALICE).unwrap();
 
 		ExtBuilder::default()
@@ -205,7 +205,11 @@ mod tests {
 					target: to_account,
 					schedule: vesting_schedule,
 				});
-				assert_ok!(call.dispatch(RuntimeOrigin::signed(alice)));
+
+				assert_err!(
+					call.dispatch(RuntimeOrigin::signed(alice)),
+					frame_system::Error::<Runtime>::CallFiltered
+				);
 			});
 	}
 

--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -88,7 +88,6 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 		use pallet_vesting::Call::*;
 
 		match c {
-			// New candidates are not allowed.
 			RuntimeCall::Vesting(vested_transfer { .. }) => false,
 			_ => true,
 		}

--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -87,10 +87,7 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 	fn contains(c: &RuntimeCall) -> bool {
 		use pallet_vesting::Call::*;
 
-		match c {
-			RuntimeCall::Vesting(vested_transfer { .. }) => false,
-			_ => true,
-		}
+		!matches!(c, RuntimeCall::Vesting(vested_transfer { .. }))
 	}
 }
 

--- a/runtime/laos/src/configs/system.rs
+++ b/runtime/laos/src/configs/system.rs
@@ -18,7 +18,7 @@ use crate::{
 	weights::RocksDbWeight, AccountId, Balance, Block, PalletInfo, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, RuntimeTask, RuntimeVersion, VERSION,
 };
-use frame_support::{parameter_types, traits::Everything};
+use frame_support::{parameter_types, traits::Contains};
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 parameter_types! {
@@ -63,7 +63,7 @@ impl frame_system::Config for Runtime {
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = Everything;
+	type BaseCallFilter = BaseCallFilter;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = ();
 	/// Block & extrinsics weights: base values and limits.
@@ -80,6 +80,19 @@ impl frame_system::Config for Runtime {
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();
+}
+
+pub struct BaseCallFilter;
+impl Contains<RuntimeCall> for BaseCallFilter {
+	fn contains(c: &RuntimeCall) -> bool {
+		use pallet_vesting::Call::*;
+
+		match c {
+			// New candidates are not allowed.
+			RuntimeCall::Vesting(vested_transfer { .. }) => false,
+			_ => true,
+		}
+	}
 }
 
 // tests


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Introduced a custom `BaseCallFilter` to exclude `vested_transfer` calls from being dispatched.
- Updated the system configuration to use the new `BaseCallFilter`.
- Modified tests to verify that `vested_transfer` calls are correctly filtered out.
- Ensured that the test for `vested_transfer` now expects an error, confirming the filter's functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system.rs</strong><dd><code>Implement custom call filter to exclude vested transfers</code>&nbsp; </dd></summary>
<hr>

runtime/laos/src/configs/system.rs

<li>Changed the <code>BaseCallFilter</code> type to filter out <code>vested_transfer</code> calls.<br> <li> Implemented a custom <code>BaseCallFilter</code> struct to exclude <code>vested_transfer</code>.<br> <li> Updated test to ensure <code>vested_transfer</code> is not allowed.<br> <li> Replaced <code>assert_ok!</code> with <code>assert_err!</code> in the test for <code>vested_transfer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/870/files#diff-fca104f1936302f2739add0ff6a4a5ff2d1d9c14e94d9a15db1f2213a6d843b8">+20/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information