### PR TITLE
Simplify Zombienet Configuration to Use a Single Collator


### DIFF
--- a/zombienet/native.toml
+++ b/zombienet/native.toml
@@ -28,18 +28,6 @@ force_decorator = "generic-evm"
   command = "{{ZOMBIENET_LAOS_COMMAND}}"
   validator = true
   args = ["--log=xcm=trace"]
-  
-  [[parachains.collators]]
-  name = "laos1"
-  command = "{{ZOMBIENET_LAOS_COMMAND}}"
-  validator = true
-  args = ["--log=xcm=trace"]
-
-    [[parachains.collators]]
-  name = "laos2"
-  command = "{{ZOMBIENET_LAOS_COMMAND}}"
-  validator = true
-  args = ["--log=xcm=trace"]
 
 [[parachains]]
 id = 1000


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Simplified the configuration by reducing the number of collators from three to one in the `zombienet/native.toml` file.
- Removed the configurations for `laos1` and `laos2` collators, leaving only `laos0`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>native.toml</strong><dd><code>Simplified collator configuration to use a single collator</code></dd></summary>
<hr>

zombienet/native.toml

<li>Reduced the number of collators from three to one.<br> <li> Removed configurations for <code>laos1</code> and <code>laos2</code> collators.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/875/files#diff-a57d1ed38aa797602014f2b35c1eda2fe0733de1c939dc4b922eb6d0fe38dc0f">+0/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information