### PR TITLE
Enable logs vesting e2e test CI

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,7 +7,7 @@
 		"fmt-check": "prettier ./tests --check",
 		"fmt": "prettier ./tests --write",
 		"build": "./compile_contracts.sh",
-		"test": "mocha -r ts-node/register -t 900000 'tests/**/*.ts'",
+		"test": "DEBUG=transaction mocha -r ts-node/register -t 900000 'tests/**/*.ts'",
 		"test-sql": "FRONTIER_BACKEND_TYPE='sql' mocha -r ts-node/register 'tests/**/*.ts'"
 	},
 	"author": "",


### PR DESCRIPTION
A quick PR to enable the logs of the vesting e2e test in the CI