### PR TITLE
Increase zombienet blocks per round to avoid invalid tx

### DIFF
--- a/node/src/chain_spec/laos.rs
+++ b/node/src/chain_spec/laos.rs
@@ -100,7 +100,7 @@ fn create_test_genesis_config() -> serde_json::Value {
 		},
 		sudo: laos_runtime::SudoConfig { key: Some(predefined_accounts::ALITH.into()) },
 		parachain_staking: laos_runtime::ParachainStakingConfig {
-			blocks_per_round: 5,
+			blocks_per_round: 500,
 			rewards_account: Some(predefined_accounts::BALTATHAR.into()),
 			inflation_config: laos_runtime::InflationInfo {
 				// staking expectations


### PR DESCRIPTION
Due to this [Issue](https://github.com/paritytech/polkadot-sdk/issues/184) concerning the ```pallet_session```, each block where a new session starts deems all tx attempted to be included in it as invalid, which is specially annoying during zombienet testing as we need to track if those tx has been finalized. For testing purposes (til the mentioned issue is addressed), we increase the number of blocks per round, which implies an increase in the number of blocks per session, in order to 'dodge' those blocks.