### PR TITLE
Update Laos Sigma Try Runtime job to use secure WebSocket endpoint


### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
           chmod +x ./try-runtime
       - name: Try Runtime for Laos Sigma
         run: |
-          RUST_LOG=try-runtime,info ./try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks=all live --uri ws://159.223.241.51:9944
+          RUST_LOG=try-runtime,info ./try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks=all live --uri wss://rpc.laossigma.laosfoundation.io
       - name: Try Runtime for Laos
         run: |
           RUST_LOG=try-runtime,info ./try-runtime --runtime ./target/release/wbuild/laos-runtime/laos_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks=all live --uri wss://rpc.laos.laosfoundation.io


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the Laos Sigma Try Runtime job in the GitHub Actions workflow to use a secure WebSocket endpoint (`wss://rpc.laossigma.laosfoundation.io`) instead of an IP-based WebSocket endpoint.
- This change improves security and aligns with best practices for endpoint usage.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Update Laos Sigma Try Runtime URI to secure WebSocket endpoint</code></dd></summary>
<hr>

.github/workflows/build.yml

<li>Updated the URI for the Laos Sigma Try Runtime job to use a secure <br>WebSocket endpoint (<code>wss://rpc.laossigma.laosfoundation.io</code>) instead of <br>an IP-based WebSocket endpoint.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/904/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information