### PR TITLE
Add custom tx pool that skip `remove_invalid` when producing block

### DIFF
--- a/node/src/custom_tx_pool.rs
+++ b/node/src/custom_tx_pool.rs
@@ -1,0 +1,100 @@
+use futures::Future;
+use sc_transaction_pool_api::{
+	ImportNotificationStream, PoolFuture, PoolStatus, ReadyTransactions, TransactionFor,
+	TransactionPool, TransactionSource, TransactionStatusStreamFor, TxHash,
+};
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
+
+pub struct CustomPool<I> {
+	inner_pool: Arc<I>,
+}
+
+impl<I> CustomPool<I> {
+	pub fn new(inner_pool: Arc<I>) -> Self {
+		Self { inner_pool }
+	}
+}
+
+impl<I> TransactionPool for CustomPool<I>
+where
+	I: TransactionPool,
+{
+	type Block = I::Block;
+	type Hash = I::Hash;
+	type InPoolTransaction = I::InPoolTransaction;
+	type Error = I::Error;
+
+	fn submit_at(
+		&self,
+		at: <Self::Block as BlockT>::Hash,
+		source: TransactionSource,
+		xts: Vec<TransactionFor<Self>>,
+	) -> PoolFuture<Vec<Result<TxHash<Self>, Self::Error>>, Self::Error> {
+		self.inner_pool.submit_at(at, source, xts)
+	}
+
+	fn submit_one(
+		&self,
+		at: <Self::Block as BlockT>::Hash,
+		source: TransactionSource,
+		xt: TransactionFor<Self>,
+	) -> PoolFuture<TxHash<Self>, Self::Error> {
+		self.inner_pool.submit_one(at, source, xt)
+	}
+
+	fn submit_and_watch(
+		&self,
+		at: <Self::Block as BlockT>::Hash,
+		source: TransactionSource,
+		xt: TransactionFor<Self>,
+	) -> PoolFuture<Pin<Box<TransactionStatusStreamFor<Self>>>, Self::Error> {
+		self.inner_pool.submit_and_watch(at, source, xt)
+	}
+
+	fn remove_invalid(&self, _: &[TxHash<Self>]) -> Vec<Arc<Self::InPoolTransaction>> {
+		// Don't do anything on purpose.
+		Vec::new()
+	}
+
+	fn status(&self) -> PoolStatus {
+		self.inner_pool.status()
+	}
+
+	fn import_notification_stream(&self) -> ImportNotificationStream<TxHash<Self>> {
+		self.inner_pool.import_notification_stream()
+	}
+
+	fn hash_of(&self, xt: &TransactionFor<Self>) -> TxHash<Self> {
+		self.inner_pool.hash_of(xt)
+	}
+
+	fn on_broadcasted(&self, propagations: HashMap<TxHash<Self>, Vec<String>>) {
+		self.inner_pool.on_broadcasted(propagations)
+	}
+
+	fn ready_transaction(&self, hash: &TxHash<Self>) -> Option<Arc<Self::InPoolTransaction>> {
+		self.inner_pool.ready_transaction(hash)
+	}
+
+	fn ready_at(
+		&self,
+		at: NumberFor<Self::Block>,
+	) -> Pin<
+		Box<
+			dyn Future<
+					Output = Box<dyn ReadyTransactions<Item = Arc<Self::InPoolTransaction>> + Send>,
+				> + Send,
+		>,
+	> {
+		self.inner_pool.ready_at(at)
+	}
+
+	fn ready(&self) -> Box<dyn ReadyTransactions<Item = Arc<Self::InPoolTransaction>> + Send> {
+		self.inner_pool.ready()
+	}
+
+	fn futures(&self) -> Vec<Self::InPoolTransaction> {
+		self.inner_pool.futures()
+	}
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -25,7 +25,7 @@ mod cli;
 mod command;
 mod eth;
 mod rpc;
-
+mod custom_tx_pool;
 fn main() -> sc_cli::Result<()> {
 	command::run()
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -23,9 +23,9 @@ mod chain_spec;
 mod service;
 mod cli;
 mod command;
+mod custom_tx_pool;
 mod eth;
 mod rpc;
-mod custom_tx_pool;
 fn main() -> sc_cli::Result<()> {
 	command::run()
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -571,10 +571,13 @@ fn start_consensus(
 	// NOTE: because we use Aura here explicitly, we can use `CollatorSybilResistance::Resistant`
 	// when starting the network.
 
+	// NOTE: temporary workaround taken from here: https://github.com/frequency-chain/frequency/pull/2196
+	let custom_transaction_pool = 	std::sync::Arc::new(crate::custom_tx_pool::CustomPool::new(transaction_pool));
+
 	let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
 		task_manager.spawn_handle(),
 		client.clone(),
-		transaction_pool,
+		custom_transaction_pool,
 		prometheus_registry,
 		telemetry.clone(),
 	);

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -571,7 +571,8 @@ fn start_consensus(
 	// NOTE: because we use Aura here explicitly, we can use `CollatorSybilResistance::Resistant`
 	// when starting the network.
 
-	// NOTE: temporary workaround taken from here: https://github.com/frequency-chain/frequency/pull/2196
+	// TODO: Remove the custom tx pool when paritytech/polkadot-sdk#4639 is included in a stable release.
+	// This is a temporary workaround taken from here: https://github.com/frequency-chain/frequency/pull/2196.
 	let custom_transaction_pool =
 		std::sync::Arc::new(crate::custom_tx_pool::CustomPool::new(transaction_pool));
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -571,8 +571,8 @@ fn start_consensus(
 	// NOTE: because we use Aura here explicitly, we can use `CollatorSybilResistance::Resistant`
 	// when starting the network.
 
-	// TODO: Remove the custom tx pool when paritytech/polkadot-sdk#4639 is included in a stable release.
-	// This is a temporary workaround taken from here: https://github.com/frequency-chain/frequency/pull/2196.
+	// TODO: Remove the custom tx pool when paritytech/polkadot-sdk#4639 is included in a stable
+	// release. This is a temporary workaround taken from here: https://github.com/frequency-chain/frequency/pull/2196.
 	let custom_transaction_pool =
 		std::sync::Arc::new(crate::custom_tx_pool::CustomPool::new(transaction_pool));
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -572,7 +572,8 @@ fn start_consensus(
 	// when starting the network.
 
 	// NOTE: temporary workaround taken from here: https://github.com/frequency-chain/frequency/pull/2196
-	let custom_transaction_pool = 	std::sync::Arc::new(crate::custom_tx_pool::CustomPool::new(transaction_pool));
+	let custom_transaction_pool =
+		std::sync::Arc::new(crate::custom_tx_pool::CustomPool::new(transaction_pool));
 
 	let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
 		task_manager.spawn_handle(),

--- a/zombienet/native.toml
+++ b/zombienet/native.toml
@@ -27,16 +27,17 @@ force_decorator = "generic-evm"
   ws_port = 9999
   command = "{{ZOMBIENET_LAOS_COMMAND}}"
   validator = true
+  args = ["--log=xcm=trace,aura=trace,txpool=trace,basic-authorship=trace"]
 
   [[parachains.collators]]
   name = "laos1"
   command = "{{ZOMBIENET_LAOS_COMMAND}}"
   validator = true
-  args = ["--log=xcm=trace"]
+  args = ["--log=xcm=trace,aura=trace,txpool=trace,basic-authorship=trace"]
 
     [[parachains.collators]]
   name = "laos2"
   command = "{{ZOMBIENET_LAOS_COMMAND}}"
   validator = true
-  args = ["--log=xcm=trace"]
+  args = ["--log=xcm=trace,aura=trace,txpool=trace,basic-authorship=trace"]
 


### PR DESCRIPTION
This serves as a workaround taken from [here](https://github.com/frequency-chain/frequency/pull/2196) until [this](https://github.com/paritytech/polkadot-sdk/pull/4639) is included in a stable release. For more information, see also [this](https://github.com/paritytech/polkadot-sdk/issues/1202#issuecomment-2531036262).