### PR TITLE
Simplify Zombienet configuration to use a single collator


### DIFF
--- a/zombienet/native.toml
+++ b/zombienet/native.toml
@@ -23,21 +23,10 @@ chain = "local"
 force_decorator = "generic-evm"
 
   [[parachains.collators]]
-  name = "laos0"
+  name = "laos"
   ws_port = 9999
   command = "{{ZOMBIENET_LAOS_COMMAND}}"
   validator = true
   args = ["--log=xcm=trace,aura=trace,txpool=trace,basic-authorship=trace"]
 
-  [[parachains.collators]]
-  name = "laos1"
-  command = "{{ZOMBIENET_LAOS_COMMAND}}"
-  validator = true
-  args = ["--log=xcm=trace,aura=trace,txpool=trace,basic-authorship=trace"]
-
-    [[parachains.collators]]
-  name = "laos2"
-  command = "{{ZOMBIENET_LAOS_COMMAND}}"
-  validator = true
-  args = ["--log=xcm=trace,aura=trace,txpool=trace,basic-authorship=trace"]
 


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Simplified the `zombienet/native.toml` configuration by reducing the number of collators from three to one.
- Updated the remaining collator's name to `laos` and removed redundant configurations for the other collators.
- Streamlined the setup for easier management and reduced complexity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>native.toml</strong><dd><code>Simplified collator configuration to a single collator</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

zombienet/native.toml

<li>Reduced the number of collators in the configuration from three to <br>one.<br> <li> Updated the remaining collator's name to <code>laos</code>.<br> <li> Removed redundant configurations for additional collators.<br>


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/920/files#diff-a57d1ed38aa797602014f2b35c1eda2fe0733de1c939dc4b922eb6d0fe38dc0f">+1/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information