### PR TITLE
feat: Remove unnecessary migrations

### DIFF
--- a/runtime/laos/src/migrations/mod.rs
+++ b/runtime/laos/src/migrations/mod.rs
@@ -14,13 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with LAOS.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{ParachainSystem, Runtime};
-
-pub type Migrations = (
-	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
-	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
-);
-
-impl cumulus_pallet_xcmp_queue::migration::v5::V5Config for Runtime {
-	type ChannelList = ParachainSystem;
-}
+pub type Migrations = ();


### PR DESCRIPTION
As we can see using try-runtime (the CI runs it for LAOS and LAOS Sigma), the migrations we have declared in our runtime are not needed anymore: 


`[2025-01-15T10:11:28Z WARN  frame_support::migrations] 🚚 Pallet "XcmpQueue" VersionedMigration migration 3->4 can be removed; on-chain is already at StorageVersion(5).`

`[2025-01-15T10:11:28Z WARN  frame_support::migrations] 🚚 Pallet "XcmpQueue" VersionedMigration migration 4->5 can be removed; on-chain is already at StorageVersion(5).`


This PR removes them from the migrations module