### PR TITLE
Upgrade Dockerfile to use Ubuntu 24.04


### DIFF
--- a/docker/laos-node.local.Dockerfile
+++ b/docker/laos-node.local.Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:24.04
 
 # show backtraces
 ENV RUST_BACKTRACE 1
 
 # Create user
-RUN useradd -m -u 1000 -U -s /bin/sh -d /laos laos 
+RUN useradd -m -u 2000 -U -s /bin/sh -d /laos laos 
 
 # Set up directories and permissions
 RUN mkdir -p /data /laos/.local/share && \
@@ -15,7 +15,7 @@ RUN mkdir -p /data /laos/.local/share && \
 USER laos
 
 # copy the compiled binary to the container
-COPY --chown=laos:laos --chmod=774 target/release/laos /usr/bin/laos
+COPY --chown=laos:laos --chmod=777 target/release/laos /usr/bin/laos
 
 # check if executable works in this container
 RUN /usr/bin/laos --version

--- a/docker/laos-node.local.Dockerfile
+++ b/docker/laos-node.local.Dockerfile
@@ -4,7 +4,7 @@ FROM docker.io/library/ubuntu:24.04
 ENV RUST_BACKTRACE 1
 
 # Create user
-RUN useradd -m -u 2000 -U -s /bin/sh -d /laos laos 
+RUN useradd -m -u 1001 -U -s /bin/sh -d /laos laos 
 
 # Set up directories and permissions
 RUN mkdir -p /data /laos/.local/share && \


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Upgraded base image to Ubuntu 24.04 in Dockerfile.

- Updated user ID for `laos` user creation.

- Adjusted file permissions for the binary copy operation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>laos-node.local.Dockerfile</strong><dd><code>Upgrade base image and adjust user and permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/laos-node.local.Dockerfile

<li>Updated base image from Ubuntu 22.04 to 24.04.<br> <li> Changed user ID for <code>laos</code> user from 1000 to 2000.<br> <li> Modified binary file permissions from 774 to 777.<br> <li> Minor formatting adjustment at the end of the file.


</details>


  </td>
  <td><a href="https://github.com/freeverseio/laos/pull/958/files#diff-6e7f5ffaa06ca34bf9c53eb7a0d83aceb569f9cffbe50c7570c3ce46002036df">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information