### PR TITLE
refactor: Move precompiles under precompiles benchmark pallet

### DIFF
--- a/runtime/laos/src/lib.rs
+++ b/runtime/laos/src/lib.rs
@@ -166,6 +166,7 @@ construct_runtime!(
 		// LAOS pallets
 		LaosEvolution: pallet_laos_evolution = 100,
 		AssetMetadataExtender: pallet_asset_metadata_extender = 101,
+		#[cfg(feature = "runtime-benchmarks")]
 		PrecompilesBenchmark: pallet_precompiles_benchmark = 102,
 		TreasuryFunding: pallet_treasury_funding = 103,
 	}


### PR DESCRIPTION
This PR aims to improve the code quality of our repo and move our precompiles under the precompiles benchmark pallet, so all precompiles related stuff is located there.

We also improve our code by renaming the benchmark functions of those pre compiles to avoid collisions, as weights for all of them are inserted into the same weight file