### PR TITLE
refactor: Remove rococo runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9557,10 +9557,8 @@ version = "17.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#47155f85a877e8c26b2249e31cdb4deb485b4067"
 dependencies = [
  "async-trait",
- "bitvec",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -9614,7 +9612,6 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
- "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -53,8 +53,8 @@ substrate-frame-rpc-system = { workspace = true }
 substrate-prometheus-endpoint = { workspace = true }
 
 # Polkadot
-polkadot-cli = { workspace = true, features = ["rococo-native"] }
-polkadot-service = { workspace = true, features = ["rococo-native"] }
+polkadot-cli = { workspace = true }
+polkadot-service = { workspace = true }
 polkadot-primitives = { workspace = true }
 xcm = { workspace = true }
 laos-primitives = { workspace = true }


### PR DESCRIPTION
Currently we're compiling the rococo runtime each time we run `cargo build` without needing it. This PR reduces our dependencies tree, getting rid of rococo