### PR TITLE
feat: add Technical committee origin to preimage ManagerOrigin

### DIFF
--- a/runtime/laos/src/configs/mod.rs
+++ b/runtime/laos/src/configs/mod.rs
@@ -21,7 +21,7 @@ mod balances;
 mod base_fee;
 mod benchmark;
 mod bounties;
-mod collective;
+pub(crate) mod collective;
 pub mod cumulus_parachain_system;
 mod cumulus_xcmp_queue;
 mod democracy;

--- a/runtime/laos/src/configs/preimage.rs
+++ b/runtime/laos/src/configs/preimage.rs
@@ -15,8 +15,9 @@
 // along with LAOS.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	configs::collective::CouncilMajority, currency::calculate_deposit, weights, AccountId, Balance,
-	Balances, Runtime, RuntimeEvent, RuntimeHoldReason,
+	configs::collective::{CouncilMajority, TechnicalCommitteeMajority},
+	currency::calculate_deposit,
+	weights, AccountId, Balance, Balances, Runtime, RuntimeEvent, RuntimeHoldReason,
 };
 use frame_support::{
 	parameter_types,
@@ -33,7 +34,10 @@ parameter_types! {
 
 impl pallet_preimage::Config for Runtime {
 	type Currency = Balances;
-	type ManagerOrigin = EitherOfDiverse<EnsureRoot<AccountId>, CouncilMajority>;
+	type ManagerOrigin = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		EitherOfDiverse<CouncilMajority, TechnicalCommitteeMajority>,
+	>;
 	type RuntimeEvent = RuntimeEvent;
 	type Consideration = HoldConsideration<
 		AccountId,

--- a/runtime/laos/src/configs/preimage.rs
+++ b/runtime/laos/src/configs/preimage.rs
@@ -24,6 +24,7 @@ use frame_support::{
 	traits::{fungible::HoldConsideration, EitherOfDiverse, LinearStoragePrice},
 };
 use frame_system::EnsureRoot;
+use parity_scale_codec::Encode;
 
 parameter_types! {
 	pub const PreimageBaseDeposit: Balance = calculate_deposit(2, 64);
@@ -46,4 +47,97 @@ impl pallet_preimage::Config for Runtime {
 		LinearStoragePrice<PreimageBaseDeposit, PreimageByteDeposit, Balance>,
 	>;
 	type WeightInfo = weights::pallet_preimage::WeightInfo<Runtime>;
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+	use crate::{
+		tests::{ExtBuilder, ALICE, BOB},
+		RuntimeCall, RuntimeOrigin, TechnicalCommittee,
+	};
+	use core::str::FromStr;
+	use frame_support::{assert_ok, dispatch::GetDispatchInfo, traits::PreimageProvider};
+	use sp_runtime::traits::Hash;
+
+	#[test]
+	fn technical_committee_can_note_preimage() {
+		let alice = AccountId::from_str(ALICE).expect("ALICE is a valid H160 address; qed");
+		let bob = AccountId::from_str(BOB).expect("BOB is a valid H160 address;qed");
+
+		ExtBuilder::default().build().execute_with(|| {
+			let system_remark_calldata = RuntimeCall::System(frame_system::Call::remark {
+				remark: "Hello world!".as_bytes().to_vec(),
+			})
+			.encode();
+
+			let hashed_calldata =
+				<Runtime as frame_system::Config>::Hashing::hash(&system_remark_calldata);
+
+			// The preimage doesn't exist
+			assert!(<pallet_preimage::Pallet<Runtime> as PreimageProvider<
+				<Runtime as frame_system::Config>::Hash,
+			>>::get_preimage(&hashed_calldata)
+			.is_none());
+
+			let threshold = 2u32;
+			// This lenghtBound is enough for a system remark
+			let lenght_bound = 19u32;
+
+			let proposal = RuntimeCall::Preimage(pallet_preimage::Call::note_preimage {
+				bytes: system_remark_calldata.clone(),
+			});
+
+			assert_ok!(TechnicalCommittee::propose(
+				RuntimeOrigin::signed(alice),
+				threshold,
+				Box::new(proposal.clone()),
+				lenght_bound
+			));
+
+			let proposal_index = 0u32;
+			let proposal_hash =
+				pallet_collective::pallet::Proposals::<Runtime, pallet_collective::Instance2>::get(
+				)[proposal_index as usize];
+			let proposal_weight_bound = proposal.get_dispatch_info().weight;
+
+			assert_ok!(TechnicalCommittee::vote(
+				RuntimeOrigin::signed(alice),
+				proposal_hash,
+				proposal_index,
+				true
+			));
+
+			assert_ok!(TechnicalCommittee::vote(
+				RuntimeOrigin::signed(bob),
+				proposal_hash,
+				proposal_index,
+				true
+			));
+
+			assert_ok!(TechnicalCommittee::close(
+				RuntimeOrigin::signed(alice),
+				proposal_hash,
+				proposal_index,
+				proposal_weight_bound,
+				lenght_bound
+			));
+
+			// The preimage exists due to the technical committee has created it. Its value is
+			// exactly the system remark calldata
+			assert!(<pallet_preimage::Pallet<Runtime> as PreimageProvider<
+				<Runtime as frame_system::Config>::Hash,
+			>>::get_preimage(&hashed_calldata)
+			.is_some());
+
+			assert_eq!(
+				<pallet_preimage::Pallet<Runtime> as PreimageProvider<
+					<Runtime as frame_system::Config>::Hash,
+				>>::get_preimage(&hashed_calldata)
+				.expect("The previous assert ensures that this is Some; qed"),
+				system_remark_calldata
+			);
+		});
+	}
 }

--- a/runtime/laos/src/tests/mod.rs
+++ b/runtime/laos/src/tests/mod.rs
@@ -61,18 +61,18 @@ impl ExtBuilder {
 			.build_storage()
 			.unwrap();
 
-		let alice = AccountId::from_str(ALICE).expect("This shouldn't fail");
 		let bob = AccountId::from_str(BOB).expect("This shouldn't fail");
+		let charlie = AccountId::from_str(CHARLIE).expect("This shouldn't fail");
 
 		let mut technical_committee_and_council_members =
 			BoundedVec::with_bounded_capacity(MaxMembersTechnicalCommittee::get() as usize);
 
 		technical_committee_and_council_members
-			.try_push(alice)
+			.try_push(bob)
 			.expect("The technical committee bound is greater than 2 members;qed");
 
 		technical_committee_and_council_members
-			.try_push(bob)
+			.try_push(charlie)
 			.expect("The technical committee bound is greater than 2 members;qed");
 
 		// get deduplicated list of all accounts and balances
@@ -124,6 +124,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 
 pub(crate) const ALICE: &str = "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac";
 pub(crate) const BOB: &str = "0x6c2b9c9b5007740e52d80dddb8e197b0c844f239";
+pub(crate) const CHARLIE: &str = "0x798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc";
 
 #[test]
 fn minimum_balance_should_be_0() {

--- a/runtime/laos/src/tests/mod.rs
+++ b/runtime/laos/src/tests/mod.rs
@@ -64,14 +64,14 @@ impl ExtBuilder {
 		let alice = AccountId::from_str(ALICE).expect("This shouldn't fail");
 		let bob = AccountId::from_str(BOB).expect("This shouldn't fail");
 
-		let mut technical_committee_members =
+		let mut technical_committee_and_council_members =
 			BoundedVec::with_bounded_capacity(MaxMembersTechnicalCommittee::get() as usize);
 
-		technical_committee_members
+		technical_committee_and_council_members
 			.try_push(alice)
 			.expect("The technical committee bound is greater than 2 members;qed");
 
-		technical_committee_members
+		technical_committee_and_council_members
 			.try_push(bob)
 			.expect("The technical committee bound is greater than 2 members;qed");
 
@@ -101,8 +101,15 @@ impl ExtBuilder {
 		.unwrap();
 
 		pallet_membership::GenesisConfig::<crate::Runtime, pallet_membership::Instance2> {
-			members: technical_committee_members,
+			members: technical_committee_and_council_members.clone(),
 			phantom: PhantomData,
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		pallet_collective::GenesisConfig::<crate::Runtime, pallet_membership::Instance1> {
+			phantom: PhantomData,
+			members: technical_committee_and_council_members.into_inner(),
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();


### PR DESCRIPTION
This PR allows the technical committee to act as `ManagerOrigin` for `pallet_preimage`